### PR TITLE
Add full terminal view of the portfolio at /terminal

### DIFF
--- a/app/easter-eggs/page.tsx
+++ b/app/easter-eggs/page.tsx
@@ -11,6 +11,14 @@ export default function EasterEggsPage() {
 
   const easterEggs = [
     {
+      title: "Full Terminal Mode",
+      description:
+        "The whole portfolio as an interactive unix-style terminal: ls, cd, cat, a working vim, tab completion, color themes, mini games (snake, tictactoe, guess, typing) and plenty of hidden commands. Try `ls -a` once you're in.",
+      sequence: "Visit /terminal",
+      icon: Terminal,
+      effect: "Browse everything on this site without touching your mouse",
+    },
+    {
       title: "Konami Code",
       description: "Enter the classic Konami Code to unlock terminal mode",
       sequence: "↑ ↑ ↓ ↓ ← → ← → B A",

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -41,6 +41,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'yearly' as const,
       priority: 0.3,
     },
+    {
+      url: `${baseUrl}/terminal`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.6,
+    },
   ]
 
   // Add dynamic project routes

--- a/app/terminal/layout.tsx
+++ b/app/terminal/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import "@/styles/terminal.css";
+
+export const metadata: Metadata = {
+  title: "terminal",
+  description:
+    "The terminal view of Rui Valente's portfolio. ls, cd, cat, vim, themes, mini games and a suspicious amount of easter eggs. Built for developers.",
+  openGraph: {
+    title: "ruivalente.com — terminal edition",
+    description:
+      "Browse my portfolio like it's 1985: a fake unix with vim, tab completion, themes and mini games.",
+    url: "https://ruivalente.com/terminal",
+  },
+  alternates: {
+    canonical: "https://ruivalente.com/terminal",
+  },
+};
+
+export default function TerminalLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+import { projects, experiences, education } from "@/lib/data";
+import { buildFileSystem } from "@/lib/terminal/build-fs";
+import { Terminal } from "@/components/terminal/terminal";
+
+function readContent(contentPath: string): string {
+  try {
+    return fs.readFileSync(path.join(process.cwd(), contentPath), "utf8");
+  } catch {
+    return "";
+  }
+}
+
+export default function TerminalPage() {
+  const contentMap: Record<string, string> = {};
+  [...projects, ...experiences, ...education].forEach((item: any) => {
+    if (item.contentPath) contentMap[item.contentPath] = readContent(item.contentPath);
+  });
+
+  const root = buildFileSystem(contentMap);
+
+  return <Terminal initialFs={root} />;
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -13,6 +13,7 @@ export function Footer() {
     { name: "Experience", path: "/experience" },
     { name: "Education", path: "/education" },
     { name: "Stack", path: "/stack" },
+    { name: "Terminal", path: "/terminal" },
   ];
 
   return (

--- a/components/terminal/matrix-rain.tsx
+++ b/components/terminal/matrix-rain.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const GLYPHS = "アイウエオカキクケコサシスセソタチツテトナニヌネノ0123456789ABCDEF<>/{}[]$#*+=";
+
+export function MatrixRain({ color }: { color: string }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let raf = 0;
+    let last = 0;
+    const fontSize = 14;
+    let drops: number[] = [];
+
+    const resize = () => {
+      canvas.width = canvas.offsetWidth;
+      canvas.height = canvas.offsetHeight;
+      drops = Array(Math.ceil(canvas.width / fontSize)).fill(1);
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    const draw = (ts: number) => {
+      raf = requestAnimationFrame(draw);
+      if (ts - last < 50) return;
+      last = ts;
+      ctx.fillStyle = "rgba(0, 0, 0, 0.08)";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = color;
+      ctx.font = `${fontSize}px monospace`;
+      drops.forEach((y, i) => {
+        const char = GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
+        ctx.fillText(char, i * fontSize, y * fontSize);
+        drops[i] = y * fontSize > canvas.height && Math.random() > 0.975 ? 0 : y + 1;
+      });
+    };
+    raf = requestAnimationFrame(draw);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", resize);
+    };
+  }, [color]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="absolute inset-0 w-full h-full pointer-events-none z-30 opacity-40"
+      aria-hidden
+    />
+  );
+}

--- a/components/terminal/run-command.tsx
+++ b/components/terminal/run-command.tsx
@@ -1,0 +1,831 @@
+import React from "react";
+import { profile, social } from "@/lib/data";
+import {
+  getNode,
+  listDir,
+  renderTree,
+  resolvePath,
+  displayPath,
+  VFile,
+  VDir,
+} from "@/lib/terminal/filesystem";
+import { TERM_THEMES } from "@/lib/terminal/themes";
+import {
+  cowsay,
+  COFFEE,
+  FORTUNES,
+  HACK_LINES,
+  NEOFETCH_LOGO,
+  RM_RF_LINES,
+  TRAIN,
+  TYPING_QUOTES,
+  VADER,
+} from "@/lib/terminal/ascii";
+import type { TermAPI } from "./types";
+
+export interface CmdSpec {
+  name: string;
+  usage: string;
+  desc: string;
+  hidden?: boolean;
+  /** what to tab-complete for the first argument */
+  complete?: "path" | "dir" | "theme" | "game" | "command";
+}
+
+export const GAMES = ["snake", "tictactoe", "guess", "typing"];
+
+export const COMMANDS: CmdSpec[] = [
+  // filesystem
+  { name: "ls", usage: "ls [-la] [path]", desc: "list directory contents", complete: "path" },
+  { name: "cd", usage: "cd <dir>", desc: "change directory", complete: "dir" },
+  { name: "pwd", usage: "pwd", desc: "print working directory" },
+  { name: "cat", usage: "cat <file>", desc: "print file contents", complete: "path" },
+  { name: "tree", usage: "tree [path]", desc: "directory tree", complete: "path" },
+  { name: "vim", usage: "vim <file>", desc: "edit a file (yes, really)", complete: "path" },
+  { name: "open", usage: "open <file|url>", desc: "open a file's link in a new tab", complete: "path" },
+  { name: "grep", usage: "grep <pattern> <file>", desc: "search inside a file" },
+  { name: "echo", usage: "echo <text>", desc: "print text" },
+  // info
+  { name: "help", usage: "help [command]", desc: "this help", complete: "command" },
+  { name: "man", usage: "man <command>", desc: "manual pages", complete: "command" },
+  { name: "neofetch", usage: "neofetch", desc: "system info, but make it fashion" },
+  { name: "whoami", usage: "whoami", desc: "who are you?" },
+  { name: "contact", usage: "contact", desc: "how to reach me" },
+  { name: "social", usage: "social", desc: "links, clickable" },
+  { name: "email", usage: "email", desc: "open your mail client" },
+  { name: "resume", usage: "resume", desc: "open my resume (pdf)" },
+  { name: "date", usage: "date", desc: "current date and time" },
+  { name: "uptime", usage: "uptime", desc: "session uptime" },
+  { name: "history", usage: "history", desc: "command history" },
+  // appearance
+  { name: "theme", usage: "theme [name]", desc: "list or switch color schemes", complete: "theme" },
+  // games
+  { name: "play", usage: "play [game]", desc: `mini games: ${GAMES.join(", ")}`, complete: "game" },
+  { name: "snake", usage: "snake", desc: "the classic. arrows/wasd" },
+  { name: "tictactoe", usage: "tictactoe", desc: "you vs a smug AI" },
+  { name: "guess", usage: "guess", desc: "number guessing, 1-100" },
+  { name: "typing", usage: "typing", desc: "wpm test" },
+  // session
+  { name: "clear", usage: "clear", desc: "clear the screen (also Ctrl+L)" },
+  { name: "gui", usage: "gui [page]", desc: "back to the clickable website" },
+  { name: "exit", usage: "exit", desc: "log out to ruivalente.com" },
+  // hidden / easter eggs
+  { name: "vi", usage: "vi <file>", desc: "vim's nickname", hidden: true, complete: "path" },
+  { name: "nano", usage: "nano <file>", desc: "we both know what happens", hidden: true, complete: "path" },
+  { name: "emacs", usage: "emacs", desc: "nope", hidden: true },
+  { name: "sudo", usage: "sudo <cmd>", desc: "with great power...", hidden: true },
+  { name: "rm", usage: "rm ...", desc: "what could go wrong", hidden: true, complete: "path" },
+  { name: "mkdir", usage: "mkdir", desc: "", hidden: true },
+  { name: "touch", usage: "touch", desc: "", hidden: true },
+  { name: "mv", usage: "mv", desc: "", hidden: true },
+  { name: "cp", usage: "cp", desc: "", hidden: true },
+  { name: "chmod", usage: "chmod", desc: "", hidden: true },
+  { name: "sl", usage: "sl", desc: "choo choo", hidden: true },
+  { name: "cowsay", usage: "cowsay <text>", desc: "moo", hidden: true },
+  { name: "fortune", usage: "fortune", desc: "wisdom", hidden: true },
+  { name: "cmatrix", usage: "cmatrix", desc: "follow the white rabbit", hidden: true },
+  { name: "matrix", usage: "matrix", desc: "alias of cmatrix", hidden: true },
+  { name: "crt", usage: "crt", desc: "scanlines", hidden: true },
+  { name: "flip", usage: "flip", desc: "(╯°□°)╯︵ ┻━┻", hidden: true },
+  { name: "glitch", usage: "glitch", desc: "reality.exe has stopped", hidden: true },
+  { name: "reset", usage: "reset", desc: "clear all effects", hidden: true },
+  { name: "hack", usage: "hack <target>", desc: "hollywood mode", hidden: true },
+  { name: "coffee", usage: "coffee", desc: "☕", hidden: true },
+  { name: "darkside", usage: "darkside", desc: "join us", hidden: true },
+  { name: "jedi", usage: "jedi", desc: "return to the light", hidden: true },
+  { name: "vimtutor", usage: "vimtutor", desc: "learn vim in 2 minutes", hidden: true },
+  { name: "ping", usage: "ping <host>", desc: "fake packets", hidden: true },
+  { name: "top", usage: "top", desc: "fake processes", hidden: true },
+  { name: "uname", usage: "uname [-a]", desc: "system name", hidden: true },
+  { name: "hostname", usage: "hostname", desc: "host name", hidden: true },
+  { name: "reboot", usage: "reboot", desc: "turn it off and on again", hidden: true },
+  { name: "uuddlrlrba", usage: "↑↑↓↓←→←→BA", desc: "you know the code", hidden: true },
+];
+
+const ExtLink = ({ href, children }: { href: string; children: React.ReactNode }) => (
+  <a className="t-link" href={href} target="_blank" rel="noopener noreferrer">
+    {children}
+  </a>
+);
+
+function findFile(t: TermAPI, arg: string): { node: VFile | null; err?: string } {
+  const abs = resolvePath(t.getCwd(), arg);
+  const node = getNode(t.fsRoot, abs);
+  if (!node) return { node: null, err: `no such file or directory: ${arg}` };
+  if (node.type === "dir") return { node: null, err: `${arg}: is a directory` };
+  return { node };
+}
+
+function looksLikeUrl(s: string) {
+  return /^https?:\/\//.test(s) || /^[\w-]+(\.[\w-]+)+(\/|$)/.test(s);
+}
+
+export function execute(raw: string, t: TermAPI): void {
+  const input = raw.trim();
+  if (!input) return;
+
+  const tokens = input.split(/\s+/);
+  const cmd = tokens[0].toLowerCase();
+  const args = tokens.slice(1);
+  const rest = input.slice(tokens[0].length).trim();
+
+  switch (cmd) {
+    // ---------- filesystem ----------
+    case "ls": {
+      const flags = args.filter((a) => a.startsWith("-")).join("");
+      const showHidden = flags.includes("a");
+      const long = flags.includes("l");
+      const pathArg = args.find((a) => !a.startsWith("-"));
+      const abs = resolvePath(t.getCwd(), pathArg ?? ".");
+      const node = getNode(t.fsRoot, abs);
+      if (!node) return t.println(`ls: cannot access '${pathArg}': no such file or directory`, "t-err");
+      if (node.type === "file") return t.println(node.name);
+      const entries = listDir(node, showHidden);
+      if (!entries.length) return t.println("(empty)", "t-dim");
+      if (long) {
+        entries.forEach((e) => {
+          const perms = e.type === "dir" ? "drwxr-xr-x" : "-rw-r--r--";
+          const size = e.type === "file" ? String(e.content.length).padStart(6) : "  4096";
+          t.print(
+            <div>
+              <span className="t-dim">{perms} rui rui {size} </span>
+              <span className={e.type === "dir" ? "t-cyan" : e.hidden ? "t-dim" : ""}>
+                {e.name}
+                {e.type === "dir" ? "/" : ""}
+              </span>
+            </div>
+          );
+        });
+      } else {
+        t.print(
+          <div className="flex flex-wrap gap-x-5 gap-y-0.5">
+            {entries.map((e) => (
+              <span key={e.name} className={e.type === "dir" ? "t-cyan" : e.hidden ? "t-dim" : ""}>
+                {e.name}
+                {e.type === "dir" ? "/" : ""}
+              </span>
+            ))}
+          </div>
+        );
+      }
+      return;
+    }
+
+    case "cd": {
+      const target = args[0] ?? "~";
+      const abs = resolvePath(t.getCwd(), target);
+      const node = getNode(t.fsRoot, abs);
+      if (!node) return t.println(`cd: no such file or directory: ${target}`, "t-err");
+      if (node.type !== "dir") return t.println(`cd: not a directory: ${target}`, "t-err");
+      t.setCwd(abs);
+      return;
+    }
+
+    case "pwd":
+      return t.println(t.getCwd());
+
+    case "cat": {
+      if (!args[0]) return t.println("cat: meow? (usage: cat <file>)", "t-warn");
+      const { node, err } = findFile(t, args[0]);
+      if (!node) return t.println(`cat: ${err}`, "t-err");
+      return t.print(<pre className="whitespace-pre-wrap break-words">{node.content}</pre>);
+    }
+
+    case "tree": {
+      const abs = resolvePath(t.getCwd(), args[0] ?? ".");
+      const node = getNode(t.fsRoot, abs);
+      if (!node || node.type !== "dir") return t.println(`tree: ${args[0] ?? "."}: not a directory`, "t-err");
+      t.println(displayPath(abs), "t-cyan");
+      return t.printLines(renderTree(node));
+    }
+
+    case "vim":
+    case "vi": {
+      if (!args[0]) {
+        t.println("vim: which file? (try `vim README.md` or `vimtutor`)", "t-warn");
+        return;
+      }
+      const abs = resolvePath(t.getCwd(), args[0]);
+      const node = getNode(t.fsRoot, abs);
+      if (node && node.type === "dir") return t.println(`vim: ${args[0]} is a directory`, "t-err");
+      return t.openVim(abs);
+    }
+
+    case "nano":
+      t.println("nano: not installed. this is a vim household.", "t-warn");
+      if (args[0]) {
+        t.println(`(fine. opening ${args[0]} in vim. you'll thank me later.)`, "t-dim");
+        return execute(`vim ${args[0]}`, t);
+      }
+      return;
+
+    case "emacs":
+      return t.printLines(
+        ["emacs: command not found", "(it's a great operating system, but this machine only has 640K of RAM)"],
+        "t-warn"
+      );
+
+    case "open": {
+      if (!args[0]) return t.println("open: usage: open <file|url>", "t-warn");
+      if (looksLikeUrl(args[0])) {
+        const url = args[0].startsWith("http") ? args[0] : `https://${args[0]}`;
+        t.println(`opening ${url} ...`, "t-dim");
+        return t.openUrl(url);
+      }
+      const { node, err } = findFile(t, args[0]);
+      if (!node) return t.println(`open: ${err}`, "t-err");
+      if (!node.url) return t.println(`open: ${args[0]} has no link attached. try cat.`, "t-warn");
+      t.println(`opening ${node.url} ...`, "t-dim");
+      return t.openUrl(node.url);
+    }
+
+    case "grep": {
+      if (args.length < 2) return t.println("grep: usage: grep <pattern> <file>", "t-warn");
+      const { node, err } = findFile(t, args[args.length - 1]);
+      if (!node) return t.println(`grep: ${err}`, "t-err");
+      const pattern = args.slice(0, -1).join(" ");
+      const matches = node.content.split("\n").filter((l) => l.toLowerCase().includes(pattern.toLowerCase()));
+      if (!matches.length) return t.println("(no matches)", "t-dim");
+      matches.forEach((line) => {
+        const idx = line.toLowerCase().indexOf(pattern.toLowerCase());
+        t.print(
+          <div className="whitespace-pre-wrap break-words">
+            {line.slice(0, idx)}
+            <span className="t-warn font-bold">{line.slice(idx, idx + pattern.length)}</span>
+            {line.slice(idx + pattern.length)}
+          </div>
+        );
+      });
+      return;
+    }
+
+    case "echo": {
+      const expanded = rest
+        .replace(/\$USER/g, t.getUser())
+        .replace(/\$HOME/g, "/home/guest")
+        .replace(/\$SHELL/g, "/bin/rsh")
+        .replace(/^["']|["']$/g, "");
+      return t.println(expanded || "");
+    }
+
+    // ---------- info ----------
+    case "help": {
+      if (args[0]) return execute(`man ${args[0]}`, t);
+      const section = (title: string, names: string[]) => {
+        t.println("");
+        t.println(`  ${title}`, "t-acc");
+        names.forEach((n) => {
+          const c = COMMANDS.find((x) => x.name === n)!;
+          t.print(
+            <div>
+              {"    "}
+              <span className="t-ok">{c.usage.padEnd(22)}</span>
+              <span className="t-dim">{c.desc}</span>
+            </div>
+          );
+        });
+      };
+      t.println("rsh — rui shell, v2.1.0", "t-cyan");
+      section("filesystem", ["ls", "cd", "pwd", "cat", "tree", "vim", "open", "grep", "echo"]);
+      section("about me", ["neofetch", "contact", "social", "email", "resume", "whoami"]);
+      section("games", ["play", "snake", "tictactoe", "guess", "typing"]);
+      section("session", ["theme", "clear", "history", "man", "gui", "exit"]);
+      t.println("");
+      t.println("  Tab completes commands & paths · ↑/↓ history · Ctrl+L clear · Ctrl+C cancel", "t-dim");
+      t.println("  psst: hidden commands exist. `ls -a` knows things.", "t-dim");
+      return;
+    }
+
+    case "man": {
+      if (!args[0]) return t.println("What manual page do you want? (try `man vim`)", "t-warn");
+      const spec = COMMANDS.find((c) => c.name === args[0].toLowerCase());
+      if (!spec) return t.println(`No manual entry for ${args[0]}`, "t-err");
+      t.println(`NAME`, "t-acc");
+      t.println(`    ${spec.name} — ${spec.desc || "undocumented. spooky."}`);
+      t.println(`SYNOPSIS`, "t-acc");
+      t.println(`    ${spec.usage}`);
+      if (spec.name === "vim") {
+        t.println(`NOTES`, "t-acc");
+        t.println("    :q quit · :w save · :wq both · i insert · Esc normal · hjkl move");
+        t.println("    full crash course: `vimtutor`");
+      }
+      return;
+    }
+
+    case "neofetch":
+    case "fetch": {
+      const mins = Math.floor((Date.now() - t.bootTime) / 60000);
+      const secs = Math.floor(((Date.now() - t.bootTime) % 60000) / 1000);
+      const info: [string, string][] = [
+        [`${t.getUser()}@ruivalente.com`, ""],
+        ["─".repeat(22), ""],
+        ["OS", "ruiOS 2.1.0 LTS (web edition)"],
+        ["Host", "ruivalente.com"],
+        ["Kernel", "next.js 13.5"],
+        ["Uptime", `${mins}m ${secs}s`],
+        ["Shell", "rsh 2.1.0"],
+        ["Theme", t.getThemeName()],
+        ["Role", profile.role],
+        ["Bio", profile.bio],
+        ["Email", profile.email],
+        ["Editor", "vim (this is not up for debate)"],
+        ["Fuel", "coffee, dangerously over the limit"],
+      ];
+      const logo = NEOFETCH_LOGO;
+      const height = Math.max(logo.length, info.length);
+      const out: React.ReactNode[] = [];
+      for (let i = 0; i < height; i++) {
+        const l = logo[i] ?? " ".repeat(logo[0].length);
+        const item = info[i];
+        out.push(
+          <div key={i} className="whitespace-pre">
+            <span className="t-acc">{l}</span>
+            {"  "}
+            {item ? (
+              item[1] ? (
+                <>
+                  <span className="t-ok">{item[0]}</span>
+                  <span className="t-dim">: </span>
+                  {item[1]}
+                </>
+              ) : (
+                <span className="t-cyan">{item[0]}</span>
+              )
+            ) : null}
+          </div>
+        );
+      }
+      return t.print(<div className="my-1">{out}</div>);
+    }
+
+    case "whoami":
+      if (t.getUser() === "root") return t.println("root. happy now?", "t-warn");
+      if (t.getUser() === "vader") return t.println("vader. your father, probably.", "t-err");
+      return t.println("guest — a developer with excellent taste in portfolios.");
+
+    case "contact":
+      t.println("reach me at:", "t-acc");
+      t.print(
+        <div className="ml-2">
+          <div>
+            <span className="t-dim">email     </span>
+            <ExtLink href={`mailto:${profile.email}`}>{profile.email}</ExtLink>
+          </div>
+          {social.map((s: any) => (
+            <div key={s.url}>
+              <span className="t-dim">{s.icon.toLowerCase().padEnd(10)}</span>
+              <ExtLink href={s.url}>{s.url}</ExtLink>
+            </div>
+          ))}
+        </div>
+      );
+      return;
+
+    case "social":
+      social.forEach((s: any) =>
+        t.print(
+          <div>
+            <span className="t-dim">{s.icon.toLowerCase().padEnd(10)}</span>
+            <ExtLink href={s.url}>{s.url}</ExtLink>
+          </div>
+        )
+      );
+      return;
+
+    case "email":
+      t.println(`opening mailto:${profile.email} ...`, "t-dim");
+      return t.openUrl(`mailto:${profile.email}`);
+
+    case "resume":
+    case "cv":
+      t.println("opening resume.pdf ...", "t-dim");
+      return t.openUrl("/resume.pdf");
+
+    case "date":
+      return t.println(new Date().toString());
+
+    case "uptime": {
+      const s = Math.floor((Date.now() - t.bootTime) / 1000);
+      return t.println(
+        `up ${Math.floor(s / 60)}m ${s % 60}s, 1 user, load average: ☕ ${(Math.random() * 2 + 1).toFixed(2)}`
+      );
+    }
+
+    case "history":
+      t.getHistory().forEach((h, i) => t.println(`  ${String(i + 1).padStart(3)}  ${h}`));
+      return;
+
+    case "uname":
+      return t.println(
+        args[0] === "-a" ? "ruiOS ruivalente.com 2.1.0-web #1 SMP x86_64 GNU/JSON" : "ruiOS"
+      );
+
+    case "hostname":
+      return t.println("ruivalente.com");
+
+    // ---------- appearance ----------
+    case "theme":
+    case "themes": {
+      if (!args[0]) {
+        t.println("available themes (theme <name>):", "t-acc");
+        TERM_THEMES.forEach((th) => {
+          const locked = th.hidden && !t.isThemeUnlocked(th.name);
+          const current = th.name === t.getThemeName();
+          t.print(
+            <div>
+              {"  "}
+              <span className={current ? "t-ok" : locked ? "t-dim" : ""}>
+                {current ? "● " : "  "}
+                {locked ? "???".padEnd(12) : th.name.padEnd(12)}
+              </span>
+              <span className="t-dim">{locked ? "locked — find the easter egg" : th.desc}</span>
+            </div>
+          );
+        });
+        return;
+      }
+      const name = args[0].toLowerCase();
+      const th = TERM_THEMES.find((x) => x.name === name);
+      if (!th) return t.println(`theme: unknown theme '${args[0]}'. run \`theme\` to list.`, "t-err");
+      if (!t.setThemeByName(name)) {
+        return t.println(`theme '${name}' is locked. it can be... earned.`, "t-warn");
+      }
+      return t.println(`theme set to ${name}`, "t-ok");
+    }
+
+    // ---------- games ----------
+    case "play": {
+      if (!args[0]) {
+        t.println("games:", "t-acc");
+        GAMES.forEach((g) => t.println(`  ${g}`));
+        t.println("usage: play <game>  (or just type the game name)", "t-dim");
+        return;
+      }
+      if (GAMES.includes(args[0])) return execute(args[0], t);
+      return t.println(`play: unknown game '${args[0]}'`, "t-err");
+    }
+
+    case "snake":
+      t.println("loading snake... (q to quit)", "t-dim");
+      return t.startSnake();
+
+    case "tictactoe":
+      return startTicTacToe(t);
+
+    case "guess":
+      return startGuess(t);
+
+    case "typing":
+      return startTyping(t);
+
+    // ---------- session ----------
+    case "clear":
+      return t.clear();
+
+    case "gui": {
+      const pages = ["projects", "experience", "education", "stack", "certificates", "easter-eggs"];
+      const page = args[0]?.toLowerCase();
+      const route = page && pages.includes(page) ? `/${page}` : "/";
+      t.println(`switching to gui mode → ${route}`, "t-dim");
+      return t.schedule(() => t.navigate(route), 400);
+    }
+
+    case "exit":
+    case "logout":
+      t.println("logout", "t-dim");
+      t.println("(returning you to the boring-but-pretty version)", "t-dim");
+      return t.schedule(() => t.navigate("/"), 600);
+
+    case "reboot":
+    case "restart": {
+      const lines = [
+        "broadcast message from root@ruivalente.com: system going down NOW",
+        "unmounting /dev/portfolio ...",
+        "saving 0 unsaved changes ...",
+        "rebooting.",
+      ];
+      lines.forEach((l, i) => t.schedule(() => t.println(l, "t-warn"), i * 350));
+      return t.schedule(() => window.location.reload(), lines.length * 350 + 400);
+    }
+
+    // ---------- easter eggs ----------
+    case "sudo": {
+      if (args[0] === "su" || (args[0] === "-i" && !args[1])) {
+        t.setUser("root");
+        t.println("you are now root.", "t-ok");
+        return t.println("with great power comes a great electricity bill.", "t-dim");
+      }
+      if (args.join(" ").startsWith("rm -rf /")) return execute(args.join(" "), t);
+      if (args.length === 0) return t.println("usage: sudo <command> (or `sudo su` if you're feeling brave)", "t-warn");
+      if (t.getUser() === "root") return execute(args.join(" "), t);
+      t.println(`${t.getUser()} is not in the sudoers file. This incident will be reported.`, "t-err");
+      return t.schedule(() => t.println("(reported to /dev/null)", "t-dim"), 900);
+    }
+
+    case "rm": {
+      const flat = args.join(" ");
+      if (/-[rf]{2}\s+\/\s*$/.test(flat) || flat === "-rf /" || flat === "-fr /") {
+        RM_RF_LINES.forEach((l, i) =>
+          t.schedule(() => t.println(l, l.startsWith("removed") || l.includes("panic") ? "t-err" : "t-dim"), i * 280)
+        );
+        t.schedule(() => t.toggleEffect("glitch", true), 2200);
+        t.schedule(() => t.toggleEffect("glitch", false), 3400);
+        return;
+      }
+      return t.println("rm: cannot remove: read-only file system (it's a website, relax)", "t-err");
+    }
+
+    case "mkdir":
+    case "touch":
+    case "mv":
+    case "cp":
+    case "chmod":
+    case "chown": {
+      const jokes: Record<string, string> = {
+        mkdir: "mkdir: permission denied. this museum has a strict no-construction policy.",
+        touch: "touch: please don't touch the exhibits.",
+        mv: "mv: everything is exactly where I want it, thanks.",
+        cp: "cp: piracy is a crime. (read-only filesystem)",
+        chmod: "chmod: nice try. 444 forever.",
+        chown: "chown: this is MY portfolio. all files belong to rui.",
+      };
+      return t.println(jokes[cmd], "t-warn");
+    }
+
+    case "sl":
+      t.print(
+        <div className="term-sl-track w-full">
+          <pre className="term-sl-train t-acc">{TRAIN}</pre>
+        </div>
+      );
+      return t.println("you meant `ls`. the train forgives you.", "t-dim");
+
+    case "cowsay":
+      return t.print(<pre className="whitespace-pre">{cowsay(rest || "moo")}</pre>);
+
+    case "fortune":
+      return t.println(FORTUNES[Math.floor(Math.random() * FORTUNES.length)], "t-warn");
+
+    case "cmatrix":
+    case "matrix":
+      t.toggleEffect("matrix");
+      return t.println("there is no spoon. (run again to wake up)", "t-ok");
+
+    case "crt":
+      t.toggleEffect("crt");
+      return t.println("CRT mode toggled. now with 100% more nostalgia.", "t-dim");
+
+    case "flip":
+      t.toggleEffect("flip");
+      return t.println("(╯°□°)╯︵ ┻━┻  (run `flip` again or `reset` to fix the table)", "t-warn");
+
+    case "glitch":
+      t.toggleEffect("glitch");
+      return t.println("r̸e̵a̷l̸i̵t̷y̸.̵e̶x̷e̸ has stopped responding (`reset` to fix)", "t-err");
+
+    case "reset":
+      t.resetEffects();
+      return t.println("all effects cleared. order restored.", "t-ok");
+
+    case "hack": {
+      const target = args[0] || "the mainframe";
+      t.println(`initiating attack on ${target} ...`, "t-err");
+      HACK_LINES.forEach((l, i) =>
+        t.schedule(() => t.println(l, l.includes("OK") || l.includes("granted") ? "t-ok" : "t-dim"), 400 + i * 380)
+      );
+      return;
+    }
+
+    case "coffee":
+    case "☕":
+      t.print(<pre className="t-warn whitespace-pre">{COFFEE}</pre>);
+      return t.println("productivity +200%. jitters +400%.", "t-dim");
+
+    case "darkside":
+    case "vader": {
+      t.unlockTheme("sith");
+      t.setThemeByName("sith");
+      t.setUser("vader");
+      t.print(<pre className="t-err whitespace-pre">{VADER}</pre>);
+      t.println("welcome to the dark side. we have cookies. 🍪", "t-err");
+      return t.println("(run `jedi` to return to the light)", "t-dim");
+    }
+
+    case "jedi":
+    case "lightside":
+      t.setUser("guest");
+      t.setThemeByName("matrix");
+      return t.println("balance restored. may the source be with you. ✨", "t-ok");
+
+    case "uuddlrlrba":
+    case "konami": {
+      t.unlockTheme("synthwave");
+      t.unlockTheme("sith");
+      t.setThemeByName("synthwave");
+      t.println("⭐ KONAMI CODE ACCEPTED — +30 lives", "t-mag");
+      return t.println("hidden themes unlocked: synthwave, sith. flex responsibly.", "t-dim");
+    }
+
+    case "vimtutor":
+      return t.openVim("/home/guest/.vimtutor");
+
+    case "ping": {
+      const host = args[0] || "ruivalente.com";
+      t.println(`PING ${host} 56(84) bytes of data.`);
+      for (let i = 0; i < 4; i++) {
+        const ms = (10 + Math.random() * 30).toFixed(1);
+        t.schedule(
+          () => t.println(`64 bytes from ${host}: icmp_seq=${i + 1} ttl=42 time=${ms} ms`),
+          (i + 1) * 500
+        );
+      }
+      return t.schedule(
+        () => t.println(`--- ${host} ping statistics ---\n4 packets transmitted, 4 received, 0% packet loss`, "t-dim"),
+        2400
+      );
+    }
+
+    case "top":
+    case "htop":
+      return t.printLines([
+        "  PID USER   %CPU %MEM  COMMAND",
+        "    1 rui    12.0  3.2  next dev",
+        "   42 rui    88.1 64.0  chrome --tab-count=147",
+        "   99 rui     4.2  1.1  vim README.md",
+        "  137 rui     0.1  0.2  coffee.service (running)",
+        "  404 rui     0.0  0.0  motivation (not found)",
+        " 1337 rui    99.9  0.1  snake --hiscore-attempt",
+      ]);
+
+    case ":q":
+    case ":q!":
+    case ":wq":
+    case ":x":
+      return t.println("this is not vim. but I respect the muscle memory.", "t-warn");
+
+    case "whois":
+      return execute("cat ~/about.txt", t);
+
+    case "42":
+      return t.println("the answer to life, the universe, and everything. you already knew.", "t-mag");
+
+    case "hello":
+    case "hi":
+      return t.println(`hello, ${t.getUser()}! 👋  type \`help\` to look around.`, "t-ok");
+
+    default:
+      t.println(`rsh: command not found: ${cmd}`, "t-err");
+      const near = COMMANDS.filter((c) => !c.hidden && c.name.startsWith(cmd[0] ?? "")).slice(0, 3);
+      if (near.length) t.println(`did you mean: ${near.map((c) => c.name).join(", ")}?`, "t-dim");
+      return;
+  }
+}
+
+// ---------- interactive mini games ----------
+
+function startGuess(t: TermAPI) {
+  const target = Math.floor(Math.random() * 100) + 1;
+  let attempts = 0;
+  t.println("I'm thinking of a number between 1 and 100. (q to give up)", "t-acc");
+  t.setInteractive({
+    prompt: "guess> ",
+    onCtrlC: () => t.println(`it was ${target}. quitter.`, "t-dim"),
+    onLine: (line) => {
+      const v = line.trim().toLowerCase();
+      if (v === "q" || v === "quit" || v === "exit") {
+        t.setInteractive(null);
+        return t.println(`it was ${target}. quitter. 😏`, "t-dim");
+      }
+      const n = parseInt(v, 10);
+      if (isNaN(n)) return t.println("numbers only, friend.", "t-warn");
+      attempts++;
+      if (n < target) return t.println("higher ↑", "t-cyan");
+      if (n > target) return t.println("lower ↓", "t-cyan");
+      t.setInteractive(null);
+      const rating =
+        attempts <= 7 ? "binary search detected. respect. 🫡" : "linear search?? we need to talk.";
+      t.println(`🎉 got it in ${attempts} ${attempts === 1 ? "try" : "tries"}! ${rating}`, "t-ok");
+    },
+  });
+}
+
+const TTT_WINS = [
+  [0, 1, 2], [3, 4, 5], [6, 7, 8],
+  [0, 3, 6], [1, 4, 7], [2, 5, 8],
+  [0, 4, 8], [2, 4, 6],
+];
+
+function startTicTacToe(t: TermAPI) {
+  const board: (null | "X" | "O")[] = Array(9).fill(null);
+
+  const winner = (): "X" | "O" | "draw" | null => {
+    for (const [a, b, c] of TTT_WINS) {
+      if (board[a] && board[a] === board[b] && board[a] === board[c]) return board[a];
+    }
+    return board.every(Boolean) ? "draw" : null;
+  };
+
+  const draw = () => {
+    const cell = (i: number) =>
+      board[i] === "X" ? (
+        <span className="t-ok"> X </span>
+      ) : board[i] === "O" ? (
+        <span className="t-err"> O </span>
+      ) : (
+        <span className="t-dim"> {i + 1} </span>
+      );
+    t.print(
+      <div className="my-1 leading-tight">
+        {[0, 3, 6].map((r) => (
+          <React.Fragment key={r}>
+            <div>
+              {cell(r)}<span className="t-dim">│</span>{cell(r + 1)}<span className="t-dim">│</span>{cell(r + 2)}
+            </div>
+            {r < 6 && <div className="t-dim">───┼───┼───</div>}
+          </React.Fragment>
+        ))}
+      </div>
+    );
+  };
+
+  const aiMove = () => {
+    const lines = TTT_WINS;
+    const tryFind = (mark: "X" | "O") => {
+      for (const [a, b, c] of lines) {
+        const cells = [board[a], board[b], board[c]];
+        if (cells.filter((x) => x === mark).length === 2 && cells.includes(null)) {
+          return [a, b, c][cells.indexOf(null)];
+        }
+      }
+      return -1;
+    };
+    let move = tryFind("O");
+    if (move < 0) move = tryFind("X");
+    if (move < 0 && board[4] === null) move = 4;
+    if (move < 0) {
+      const corners = [0, 2, 6, 8].filter((i) => board[i] === null);
+      if (corners.length) move = corners[Math.floor(Math.random() * corners.length)];
+    }
+    if (move < 0) {
+      const free = board.map((v, i) => (v === null ? i : -1)).filter((i) => i >= 0);
+      move = free[Math.floor(Math.random() * free.length)];
+    }
+    board[move] = "O";
+  };
+
+  const finish = (w: "X" | "O" | "draw") => {
+    t.setInteractive(null);
+    if (w === "X") t.println("you win?! impossible. I demand a rematch.", "t-ok");
+    else if (w === "O") t.println("I win. as foretold by the prophecy. 😎", "t-err");
+    else t.println("a draw. the only winning move is not to play. — WOPR", "t-warn");
+  };
+
+  t.println("tic-tac-toe — you are X. pick a cell (1-9), q to quit.", "t-acc");
+  draw();
+  t.setInteractive({
+    prompt: "move> ",
+    onLine: (line) => {
+      const v = line.trim().toLowerCase();
+      if (v === "q" || v === "quit") {
+        t.setInteractive(null);
+        return t.println("rage quit logged. 📋", "t-dim");
+      }
+      const n = parseInt(v, 10);
+      if (isNaN(n) || n < 1 || n > 9) return t.println("pick a number 1-9.", "t-warn");
+      if (board[n - 1]) return t.println("that cell is taken. eyes on the board!", "t-warn");
+      board[n - 1] = "X";
+      let w = winner();
+      if (!w) {
+        aiMove();
+        w = winner();
+      }
+      draw();
+      if (w) finish(w);
+    },
+  });
+}
+
+function startTyping(t: TermAPI) {
+  const quote = TYPING_QUOTES[Math.floor(Math.random() * TYPING_QUOTES.length)];
+  t.println("typing test — type this line and hit Enter:", "t-acc");
+  t.println(`  ${quote}`, "t-cyan");
+  const start = Date.now();
+  t.setInteractive({
+    prompt: "type> ",
+    onLine: (line) => {
+      t.setInteractive(null);
+      const seconds = (Date.now() - start) / 1000;
+      const typed = line.trim();
+      let correct = 0;
+      for (let i = 0; i < Math.min(typed.length, quote.length); i++) {
+        if (typed[i] === quote[i]) correct++;
+      }
+      const accuracy = Math.round((correct / quote.length) * 100);
+      const wpm = Math.round(typed.length / 5 / (seconds / 60));
+      t.println(`time: ${seconds.toFixed(1)}s · wpm: ${wpm} · accuracy: ${accuracy}%`, "t-ok");
+      if (accuracy < 80) t.println("accuracy is a feature, not a bug. try again!", "t-warn");
+      else if (wpm > 80) t.println("mechanical keyboard detected. 🔥", "t-mag");
+      else t.println("not bad! run `typing` for another round.", "t-dim");
+    },
+  });
+}

--- a/components/terminal/snake.tsx
+++ b/components/terminal/snake.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+const COLS = 28;
+const ROWS = 16;
+const HISCORE_KEY = "term-snake-hiscore";
+
+type Pos = { x: number; y: number };
+type Dir = "up" | "down" | "left" | "right";
+
+interface SnakeProps {
+  onExit: (score: number, hiscore: number) => void;
+}
+
+export function SnakeGame({ onExit }: SnakeProps) {
+  const [, forceRender] = useState(0);
+  const snake = useRef<Pos[]>([
+    { x: 8, y: 8 },
+    { x: 7, y: 8 },
+    { x: 6, y: 8 },
+  ]);
+  const dir = useRef<Dir>("right");
+  const nextDir = useRef<Dir>("right");
+  const food = useRef<Pos>({ x: 18, y: 8 });
+  const score = useRef(0);
+  const dead = useRef(false);
+  const paused = useRef(false);
+  const hiscore = useRef(0);
+
+  useEffect(() => {
+    hiscore.current = Number(localStorage.getItem(HISCORE_KEY) || 0);
+  }, []);
+
+  const placeFood = useCallback(() => {
+    let p: Pos;
+    do {
+      p = { x: Math.floor(Math.random() * COLS), y: Math.floor(Math.random() * ROWS) };
+    } while (snake.current.some((s) => s.x === p.x && s.y === p.y));
+    food.current = p;
+  }, []);
+
+  const exit = useCallback(() => {
+    if (score.current > hiscore.current) {
+      hiscore.current = score.current;
+      localStorage.setItem(HISCORE_KEY, String(hiscore.current));
+    }
+    onExit(score.current, hiscore.current);
+  }, [onExit]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const k = e.key.toLowerCase();
+      const map: Record<string, Dir> = {
+        arrowup: "up", w: "up",
+        arrowdown: "down", s: "down",
+        arrowleft: "left", a: "left",
+        arrowright: "right", d: "right",
+      };
+      if (map[k]) {
+        e.preventDefault();
+        const nd = map[k];
+        const opposite: Record<Dir, Dir> = { up: "down", down: "up", left: "right", right: "left" };
+        if (nd !== opposite[dir.current]) nextDir.current = nd;
+      } else if (k === "p") {
+        paused.current = !paused.current;
+        forceRender((n) => n + 1);
+      } else if (k === "q" || k === "escape") {
+        e.preventDefault();
+        exit();
+      } else if (k === "enter" && dead.current) {
+        snake.current = [
+          { x: 8, y: 8 },
+          { x: 7, y: 8 },
+          { x: 6, y: 8 },
+        ];
+        dir.current = "right";
+        nextDir.current = "right";
+        score.current = 0;
+        dead.current = false;
+        placeFood();
+        forceRender((n) => n + 1);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [exit, placeFood]);
+
+  useEffect(() => {
+    const tick = () => {
+      if (dead.current || paused.current) return;
+      dir.current = nextDir.current;
+      const head = snake.current[0];
+      const delta: Record<Dir, Pos> = {
+        up: { x: 0, y: -1 },
+        down: { x: 0, y: 1 },
+        left: { x: -1, y: 0 },
+        right: { x: 1, y: 0 },
+      };
+      const nh = { x: head.x + delta[dir.current].x, y: head.y + delta[dir.current].y };
+      if (
+        nh.x < 0 || nh.x >= COLS || nh.y < 0 || nh.y >= ROWS ||
+        snake.current.some((s) => s.x === nh.x && s.y === nh.y)
+      ) {
+        dead.current = true;
+        if (score.current > hiscore.current) {
+          hiscore.current = score.current;
+          localStorage.setItem(HISCORE_KEY, String(hiscore.current));
+        }
+        forceRender((n) => n + 1);
+        return;
+      }
+      snake.current = [nh, ...snake.current];
+      if (nh.x === food.current.x && nh.y === food.current.y) {
+        score.current += 10;
+        placeFood();
+      } else {
+        snake.current.pop();
+      }
+      forceRender((n) => n + 1);
+    };
+    const id = setInterval(tick, Math.max(60, 130 - Math.floor(score.current / 50) * 10));
+    return () => clearInterval(id);
+  });
+
+  const rows: React.ReactNode[] = [];
+  for (let y = 0; y < ROWS; y++) {
+    const cells: React.ReactNode[] = [];
+    for (let x = 0; x < COLS; x++) {
+      const isHead = snake.current[0].x === x && snake.current[0].y === y;
+      const isBody = !isHead && snake.current.some((s) => s.x === x && s.y === y);
+      const isFood = food.current.x === x && food.current.y === y;
+      if (isHead) cells.push(<span key={x} className="t-acc">█</span>);
+      else if (isBody) cells.push(<span key={x} className="t-ok">▓</span>);
+      else if (isFood) cells.push(<span key={x} className="t-err">●</span>);
+      else cells.push(<span key={x} className="t-dim" style={{ opacity: 0.25 }}>·</span>);
+    }
+    rows.push(<div key={y}>{cells}</div>);
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full select-none">
+      <div className="t-dim mb-2 text-xs">
+        score <span className="t-warn">{score.current}</span>
+        {"  ·  "}hi <span className="t-warn">{Math.max(hiscore.current, score.current)}</span>
+        {"  ·  "}wasd/arrows move · p pause · q quit
+      </div>
+      <pre className="leading-[1.05] text-base border px-2 py-1" style={{ borderColor: "var(--t-dim)" }}>
+        {rows}
+      </pre>
+      {dead.current && (
+        <div className="mt-3 text-center">
+          <div className="t-err font-bold">GAME OVER</div>
+          <div className="t-dim text-xs mt-1">enter to restart · q to quit</div>
+        </div>
+      )}
+      {paused.current && !dead.current && <div className="t-warn mt-3">PAUSED</div>}
+    </div>
+  );
+}

--- a/components/terminal/terminal.tsx
+++ b/components/terminal/terminal.tsx
@@ -1,0 +1,538 @@
+"use client";
+
+import React, {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useRouter } from "next/navigation";
+import { profile } from "@/lib/data";
+import {
+  VDir,
+  VFile,
+  HOME,
+  getNode,
+  resolvePath,
+  displayPath,
+  completePath,
+  file as makeFile,
+} from "@/lib/terminal/filesystem";
+import { TERM_THEMES, DEFAULT_THEME, getTheme } from "@/lib/terminal/themes";
+import { BANNER } from "@/lib/terminal/ascii";
+import { COMMANDS, GAMES, execute } from "./run-command";
+import { VimEditor } from "./vim";
+import { SnakeGame } from "./snake";
+import { MatrixRain } from "./matrix-rain";
+import type { EffectName, InteractiveHandler, TermAPI } from "./types";
+
+const THEME_KEY = "term-theme";
+const UNLOCKED_KEY = "term-unlocked-themes";
+const HISTORY_KEY = "term-history";
+
+interface Line {
+  id: number;
+  node: ReactNode;
+}
+
+type View =
+  | { kind: "shell" }
+  | { kind: "vim"; path: string; name: string; content: string; readOnly: boolean }
+  | { kind: "snake" };
+
+export function Terminal({ initialFs }: { initialFs: VDir }) {
+  const router = useRouter();
+  const fsRef = useRef<VDir>(initialFs);
+
+  const [lines, setLines] = useState<Line[]>([]);
+  const lineId = useRef(0);
+
+  const [input, setInput] = useState("");
+  const [cwd, _setCwd] = useState(HOME);
+  const cwdRef = useRef(HOME);
+  const [user, _setUser] = useState("guest");
+  const userRef = useRef("guest");
+
+  const [themeName, _setThemeName] = useState(DEFAULT_THEME);
+  const themeRef = useRef(DEFAULT_THEME);
+  const unlockedRef = useRef<string[]>([]);
+  const [, setUnlockedVersion] = useState(0);
+
+  const [view, setView] = useState<View>({ kind: "shell" });
+  const [effects, setEffects] = useState<Record<EffectName, boolean>>({
+    matrix: false,
+    crt: false,
+    flip: false,
+    glitch: false,
+  });
+
+  const historyRef = useRef<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const interactiveRef = useRef<InteractiveHandler | null>(null);
+  const [interactivePrompt, setInteractivePrompt] = useState<string | null>(null);
+  const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const bootTime = useRef(Date.now());
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // ---------- printing ----------
+  const print = useCallback((node: ReactNode) => {
+    setLines((prev) => [...prev, { id: lineId.current++, node }]);
+  }, []);
+
+  const println = useCallback(
+    (text = "", cls?: string) => {
+      print(
+        <div className={`whitespace-pre-wrap break-words ${cls ?? ""}`}>
+          {text === "" ? " " : text}
+        </div>
+      );
+    },
+    [print]
+  );
+
+  const printLines = useCallback(
+    (texts: string[], cls?: string) => texts.forEach((l) => println(l, cls)),
+    [println]
+  );
+
+  const clear = useCallback(() => setLines([]), []);
+
+  // ---------- state setters keeping refs in sync ----------
+  const setCwd = useCallback((p: string) => {
+    cwdRef.current = p;
+    _setCwd(p);
+  }, []);
+
+  const setUser = useCallback((u: string) => {
+    userRef.current = u;
+    _setUser(u);
+  }, []);
+
+  const setThemeName = useCallback((n: string) => {
+    themeRef.current = n;
+    _setThemeName(n);
+    try {
+      localStorage.setItem(THEME_KEY, n);
+    } catch {}
+  }, []);
+
+  // ---------- boot ----------
+  const booted = useRef(false);
+  useEffect(() => {
+    if (booted.current) return;
+    booted.current = true;
+
+    try {
+      const saved = localStorage.getItem(THEME_KEY);
+      const unlocked = JSON.parse(localStorage.getItem(UNLOCKED_KEY) || "[]");
+      if (Array.isArray(unlocked)) unlockedRef.current = unlocked;
+      if (saved && TERM_THEMES.some((t) => t.name === saved && (!t.hidden || unlocked.includes(saved)))) {
+        setThemeName(saved);
+      }
+      const hist = JSON.parse(localStorage.getItem(HISTORY_KEY) || "[]");
+      if (Array.isArray(hist)) historyRef.current = hist.slice(-100);
+    } catch {}
+
+    print(<pre className="t-acc text-[10px] sm:text-xs leading-tight whitespace-pre overflow-x-auto">{BANNER}</pre>);
+    println("");
+    print(
+      <div>
+        <span className="t-ok">ruiOS 2.1.0 LTS</span>
+        <span className="t-dim"> — the terminal view of </span>
+        <span className="t-cyan">ruivalente.com</span>
+      </div>
+    );
+    println(`${profile.name} · ${profile.role} · ${profile.bio}`, "t-dim");
+    println("");
+    print(
+      <div className="t-dim">
+        type <span className="t-warn">help</span> for commands · <span className="t-warn">ls</span> to look
+        around · <span className="t-warn">cat README.md</span> for the tour ·{" "}
+        <span className="t-warn">gui</span> for the classic site
+      </div>
+    );
+    println("");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // auto-scroll
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [lines, view]);
+
+  // refocus when returning to shell
+  useEffect(() => {
+    if (view.kind === "shell") inputRef.current?.focus();
+  }, [view]);
+
+  useEffect(() => () => timeoutsRef.current.forEach(clearTimeout), []);
+
+  // ---------- TermAPI ----------
+  const api = useMemo<TermAPI>(() => {
+    const schedule = (fn: () => void, ms: number) => {
+      timeoutsRef.current.push(setTimeout(fn, ms));
+    };
+    return {
+      get fsRoot() {
+        return fsRef.current;
+      },
+      getCwd: () => cwdRef.current,
+      setCwd,
+      print,
+      println,
+      printLines,
+      clear,
+      getUser: () => userRef.current,
+      setUser,
+      getThemeName: () => themeRef.current,
+      setThemeByName: (name: string) => {
+        const th = TERM_THEMES.find((t) => t.name === name);
+        if (!th) return false;
+        if (th.hidden && !unlockedRef.current.includes(name)) return false;
+        setThemeName(name);
+        return true;
+      },
+      unlockTheme: (name: string) => {
+        if (!unlockedRef.current.includes(name)) {
+          unlockedRef.current = [...unlockedRef.current, name];
+          setUnlockedVersion((v) => v + 1);
+          try {
+            localStorage.setItem(UNLOCKED_KEY, JSON.stringify(unlockedRef.current));
+          } catch {}
+        }
+      },
+      isThemeUnlocked: (name: string) => unlockedRef.current.includes(name),
+      openVim: (absPath: string) => {
+        const node = getNode(fsRef.current, absPath);
+        const name = absPath.split("/").filter(Boolean).pop() || "untitled";
+        setView({
+          kind: "vim",
+          path: absPath,
+          name,
+          content: node && node.type === "file" ? node.content : "",
+          readOnly: !!(node && node.type === "file" && node.readOnly),
+        });
+      },
+      startSnake: () => setView({ kind: "snake" }),
+      setInteractive: (h: InteractiveHandler | null) => {
+        interactiveRef.current = h;
+        setInteractivePrompt(h ? h.prompt : null);
+      },
+      toggleEffect: (effect: EffectName, force?: boolean) =>
+        setEffects((prev) => ({ ...prev, [effect]: force ?? !prev[effect] })),
+      resetEffects: () =>
+        setEffects({ matrix: false, crt: false, flip: false, glitch: false }),
+      navigate: (route: string) => router.push(route),
+      openUrl: (url: string) => window.open(url, "_blank", "noopener,noreferrer"),
+      schedule,
+      getHistory: () => historyRef.current,
+      bootTime: bootTime.current,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ---------- prompt ----------
+  const promptNode = (u: string, path: string) => (
+    <>
+      <span className="t-ok">{u}@rui</span>
+      <span className="t-dim">:</span>
+      <span className="t-cyan">{displayPath(path)}</span>
+      <span className="t-acc">{u === "root" ? "# " : "$ "}</span>
+    </>
+  );
+
+  const echoInput = useCallback(
+    (value: string) => {
+      const u = userRef.current;
+      const p = cwdRef.current;
+      const ip = interactiveRef.current?.prompt ?? null;
+      print(
+        <div className="whitespace-pre-wrap break-words">
+          {ip ? <span className="t-mag">{ip}</span> : promptNode(u, p)}
+          {value}
+        </div>
+      );
+    },
+    [print]
+  );
+
+  // ---------- submit ----------
+  const submit = useCallback(
+    (value: string) => {
+      echoInput(value);
+      setInput("");
+      setHistoryIndex(-1);
+      const handler = interactiveRef.current;
+      if (handler) {
+        handler.onLine(value);
+        return;
+      }
+      if (value.trim()) {
+        historyRef.current = [...historyRef.current, value].slice(-100);
+        try {
+          localStorage.setItem(HISTORY_KEY, JSON.stringify(historyRef.current));
+        } catch {}
+        execute(value, api);
+      }
+    },
+    [api, echoInput]
+  );
+
+  // ---------- tab completion ----------
+  const handleTab = useCallback(() => {
+    const val = input;
+    if (interactiveRef.current) return;
+    const endsWithSpace = /\s$/.test(val);
+    const tokens = val.trim() === "" ? [] : val.trim().split(/\s+/);
+    if (tokens.length === 0) return;
+
+    const apply = (cands: string[], partial: string, addSpace: boolean, display?: string[]) => {
+      if (cands.length === 0) return;
+      const replaceLast = (replacement: string) => {
+        if (endsWithSpace) return val + replacement;
+        const idx = val.lastIndexOf(partial);
+        return val.slice(0, idx) + replacement;
+      };
+      if (cands.length === 1) {
+        const c = cands[0];
+        setInput(replaceLast(c) + (addSpace && !c.endsWith("/") ? " " : ""));
+        return;
+      }
+      const lcp = cands.reduce((a, b) => {
+        let i = 0;
+        while (i < a.length && i < b.length && a[i] === b[i]) i++;
+        return a.slice(0, i);
+      });
+      if (lcp.length > partial.length) {
+        setInput(replaceLast(lcp));
+      } else {
+        echoInput(val);
+        print(
+          <div className="flex flex-wrap gap-x-5 t-dim">
+            {(display ?? cands).map((c, i) => (
+              <span key={i}>{c}</span>
+            ))}
+          </div>
+        );
+      }
+    };
+
+    const completingFirst = tokens.length === 1 && !endsWithSpace;
+    if (completingFirst) {
+      const prefix = tokens[0].toLowerCase();
+      const cands = COMMANDS.filter((c) => !c.hidden && c.name.startsWith(prefix)).map((c) => c.name);
+      apply(cands, tokens[0], true);
+      return;
+    }
+
+    const spec = COMMANDS.find((c) => c.name === tokens[0].toLowerCase());
+    if (!spec?.complete) return;
+    const partial = endsWithSpace ? "" : tokens[tokens.length - 1];
+
+    if (spec.complete === "theme") {
+      const cands = TERM_THEMES.filter((t) => !t.hidden || unlockedRef.current.includes(t.name))
+        .map((t) => t.name)
+        .filter((n) => n.startsWith(partial.toLowerCase()));
+      apply(cands, partial, true);
+    } else if (spec.complete === "game") {
+      apply(GAMES.filter((g) => g.startsWith(partial.toLowerCase())), partial, true);
+    } else if (spec.complete === "command") {
+      const cands = COMMANDS.filter((c) => !c.hidden && c.name.startsWith(partial.toLowerCase())).map(
+        (c) => c.name
+      );
+      apply(cands, partial, true);
+    } else {
+      const cands = completePath(fsRef.current, cwdRef.current, partial, spec.complete === "dir");
+      const display = cands.map((c) => c.split("/").filter(Boolean).pop() + (c.endsWith("/") ? "/" : ""));
+      apply(cands, partial, true, display);
+    }
+  }, [input, echoInput, print]);
+
+  // ---------- key handling ----------
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submit(input);
+    } else if (e.key === "Tab") {
+      e.preventDefault();
+      handleTab();
+    } else if (e.key === "c" && e.ctrlKey) {
+      e.preventDefault();
+      timeoutsRef.current.forEach(clearTimeout);
+      timeoutsRef.current = [];
+      const handler = interactiveRef.current;
+      echoInput(input + "^C");
+      setInput("");
+      setHistoryIndex(-1);
+      if (handler) {
+        interactiveRef.current = null;
+        setInteractivePrompt(null);
+        handler.onCtrlC?.();
+      }
+    } else if (e.key === "l" && e.ctrlKey) {
+      e.preventDefault();
+      clear();
+    } else if (e.key === "u" && e.ctrlKey) {
+      e.preventDefault();
+      setInput("");
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (interactiveRef.current) return;
+      const h = historyRef.current;
+      if (!h.length) return;
+      const ni = historyIndex < h.length - 1 ? historyIndex + 1 : historyIndex;
+      setHistoryIndex(ni);
+      setInput(h[h.length - 1 - ni] ?? "");
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (interactiveRef.current) return;
+      const h = historyRef.current;
+      const ni = historyIndex > -1 ? historyIndex - 1 : -1;
+      setHistoryIndex(ni);
+      setInput(ni === -1 ? "" : h[h.length - 1 - ni] ?? "");
+    }
+  };
+
+  // ---------- vim save ----------
+  const handleVimSave = useCallback((path: string, content: string): string | null => {
+    const node = getNode(fsRef.current, path);
+    if (node) {
+      if (node.type === "dir") return "E17: is a directory";
+      if (node.readOnly) return "E45: 'readonly' option is set";
+      (node as VFile).content = content;
+      return null;
+    }
+    const segs = path.split("/").filter(Boolean);
+    const name = segs.pop()!;
+    const parent = getNode(fsRef.current, "/" + segs.join("/"));
+    if (!parent || parent.type !== "dir") return "E212: Can't open file for writing";
+    parent.children[name] = makeFile(name, content);
+    return null;
+  }, []);
+
+  const theme = getTheme(themeName);
+  const cssVars = {
+    "--t-bg": theme.colors.bg,
+    "--t-fg": theme.colors.fg,
+    "--t-dim": theme.colors.dim,
+    "--t-accent": theme.colors.accent,
+    "--t-green": theme.colors.green,
+    "--t-red": theme.colors.red,
+    "--t-yellow": theme.colors.yellow,
+    "--t-cyan": theme.colors.cyan,
+    "--t-magenta": theme.colors.magenta,
+    "--t-selection": theme.colors.selection,
+  } as React.CSSProperties;
+
+  const rootClasses = [
+    "term-root fixed inset-0 z-[100] flex flex-col text-sm",
+    effects.crt ? "term-crt" : "",
+    effects.flip ? "term-flip" : "",
+    effects.glitch ? "term-glitch" : "",
+  ].join(" ");
+
+  return (
+    <div className={rootClasses} style={cssVars}>
+      {/* title bar */}
+      <div
+        className="shrink-0 flex items-center gap-2 px-3 py-2 border-b select-none"
+        style={{ borderColor: "var(--t-selection)" }}
+      >
+        <span className="flex gap-1.5">
+          <span className="w-3 h-3 rounded-full" style={{ background: "#ff5f57" }} />
+          <span className="w-3 h-3 rounded-full" style={{ background: "#febc2e" }} />
+          <span className="w-3 h-3 rounded-full" style={{ background: "#28c840" }} />
+        </span>
+        <span className="t-dim text-xs flex-1 text-center truncate">
+          {user}@ruivalente.com — {displayPath(cwd)} — rsh
+        </span>
+        <button
+          onClick={() => router.push("/")}
+          className="t-dim text-xs hover:underline"
+          title="back to the classic website"
+        >
+          [gui]
+        </button>
+      </div>
+
+      {/* main area */}
+      <div className="relative flex-1 min-h-0">
+        {effects.matrix && <MatrixRain color={theme.colors.green} />}
+
+        {view.kind === "shell" && (
+          <div
+            ref={scrollRef}
+            className="h-full overflow-y-auto term-scrollbar px-3 py-2 cursor-text"
+            onClick={() => {
+              if (!window.getSelection()?.toString()) inputRef.current?.focus();
+            }}
+          >
+            {lines.map((l) => (
+              <div key={l.id}>{l.node}</div>
+            ))}
+            <div className="flex items-baseline whitespace-pre-wrap">
+              <span className="shrink-0">
+                {interactivePrompt ? (
+                  <span className="t-mag">{interactivePrompt}</span>
+                ) : (
+                  promptNode(user, cwd)
+                )}
+              </span>
+              <input
+                ref={inputRef}
+                className="term-input"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={onKeyDown}
+                autoFocus
+                autoCapitalize="off"
+                autoCorrect="off"
+                autoComplete="off"
+                spellCheck={false}
+                aria-label="terminal input"
+              />
+            </div>
+          </div>
+        )}
+
+        {view.kind === "vim" && (
+          <VimEditor
+            filename={view.name}
+            content={view.content}
+            readOnly={view.readOnly}
+            onSave={(content) => handleVimSave(view.path, content)}
+            onExit={() => {
+              setView({ kind: "shell" });
+              println("");
+            }}
+          />
+        )}
+
+        {view.kind === "snake" && (
+          <SnakeGame
+            onExit={(score, hi) => {
+              setView({ kind: "shell" });
+              println(`snake: final score ${score} · best ${hi}`, "t-warn");
+            }}
+          />
+        )}
+      </div>
+
+      {/* hint bar */}
+      <div
+        className="shrink-0 px-3 py-1 border-t text-[10px] t-dim flex justify-between gap-2 select-none"
+        style={{ borderColor: "var(--t-selection)" }}
+      >
+        <span className="truncate">
+          help · tab completes · ↑↓ history · games: {GAMES.join(" ")} · theme {theme.name}
+        </span>
+        <span className="hidden sm:inline shrink-0">ruivalente.com/terminal</span>
+      </div>
+    </div>
+  );
+}

--- a/components/terminal/types.ts
+++ b/components/terminal/types.ts
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import type { VDir } from "@/lib/terminal/filesystem";
+
+/** When set, the next input line is fed to the handler instead of the shell. */
+export interface InteractiveHandler {
+  prompt: string;
+  onLine: (line: string) => void;
+  onCtrlC?: () => void;
+}
+
+export type EffectName = "matrix" | "crt" | "flip" | "glitch";
+
+/** Everything a command needs to talk back to the terminal. */
+export interface TermAPI {
+  fsRoot: VDir;
+  getCwd(): string;
+  setCwd(path: string): void;
+  print(node: ReactNode): void;
+  println(text?: string, cls?: string): void;
+  printLines(lines: string[], cls?: string): void;
+  clear(): void;
+  getUser(): string;
+  setUser(user: string): void;
+  getThemeName(): string;
+  /** returns false if the theme doesn't exist or is still locked */
+  setThemeByName(name: string): boolean;
+  unlockTheme(name: string): void;
+  isThemeUnlocked(name: string): boolean;
+  openVim(path: string): void;
+  startSnake(): void;
+  setInteractive(handler: InteractiveHandler | null): void;
+  toggleEffect(effect: EffectName, force?: boolean): void;
+  resetEffects(): void;
+  navigate(route: string): void;
+  openUrl(url: string): void;
+  /** setTimeout that is cancelled if the user hits Ctrl+C / unmounts */
+  schedule(fn: () => void, ms: number): void;
+  getHistory(): string[];
+  bootTime: number;
+}

--- a/components/terminal/vim.tsx
+++ b/components/terminal/vim.tsx
@@ -1,0 +1,455 @@
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+type Mode = "normal" | "insert" | "command";
+
+interface VimProps {
+  filename: string;
+  content: string;
+  readOnly?: boolean;
+  /** returns an error message, or null on success */
+  onSave: (content: string) => string | null;
+  onExit: () => void;
+}
+
+interface Snapshot {
+  lines: string[];
+  row: number;
+  col: number;
+}
+
+export function VimEditor({ filename, content, readOnly, onSave, onExit }: VimProps) {
+  const [lines, setLines] = useState<string[]>(() => {
+    const l = content.split("\n");
+    return l.length ? l : [""];
+  });
+  const [row, setRow] = useState(0);
+  const [col, setCol] = useState(0);
+  const [mode, setMode] = useState<Mode>("normal");
+  const [cmdline, setCmdline] = useState("");
+  const [message, setMessage] = useState(
+    `"${filename}" ${content.split("\n").length}L — :q quit · :wq save · i insert · /search`
+  );
+  const [modified, setModified] = useState(false);
+  const [showNumbers, setShowNumbers] = useState(true);
+
+  const pending = useRef<string>("");
+  const undoStack = useRef<Snapshot[]>([]);
+  const yankBuf = useRef<string[] | null>(null);
+  const searchTerm = useRef("");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const cursorRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    cursorRef.current?.scrollIntoView({ block: "nearest" });
+  }, [row, col, mode, lines]);
+
+  const clampCol = useCallback(
+    (r: number, c: number, insert: boolean) => {
+      const len = (lines[r] ?? "").length;
+      const max = insert ? len : Math.max(0, len - 1);
+      return Math.max(0, Math.min(c, max));
+    },
+    [lines]
+  );
+
+  const snapshot = useCallback(() => {
+    undoStack.current.push({ lines: [...lines], row, col });
+    if (undoStack.current.length > 200) undoStack.current.shift();
+  }, [lines, row, col]);
+
+  const mutate = useCallback(
+    (newLines: string[], r?: number, c?: number) => {
+      setLines(newLines.length ? newLines : [""]);
+      setModified(true);
+      if (r !== undefined) setRow(Math.max(0, Math.min(r, newLines.length - 1)));
+      if (c !== undefined) setCol(Math.max(0, c));
+    },
+    []
+  );
+
+  const moveTo = useCallback(
+    (r: number, c: number, insert = false) => {
+      const nr = Math.max(0, Math.min(r, lines.length - 1));
+      setRow(nr);
+      setCol(clampCol(nr, c, insert));
+    },
+    [lines, clampCol]
+  );
+
+  const wordJump = useCallback(
+    (forward: boolean, end: boolean) => {
+      const text = lines[row] ?? "";
+      const isWord = (ch: string | undefined) => !!ch && /\w/.test(ch);
+      if (forward) {
+        let idx = -1;
+        for (let i = col + 1; i < text.length; i++) {
+          if (end) {
+            if (isWord(text[i]) && !isWord(text[i + 1])) { idx = i; break; }
+          } else if (isWord(text[i]) && !isWord(text[i - 1])) { idx = i; break; }
+        }
+        if (idx >= 0) moveTo(row, idx);
+        else if (row < lines.length - 1) moveTo(row + 1, 0);
+      } else {
+        const before = text.slice(0, col);
+        const m = before.match(/\w+\W*$/);
+        if (m && m.index !== undefined) moveTo(row, m.index);
+        else if (row > 0) moveTo(row - 1, Math.max(0, (lines[row - 1] ?? "").length - 1));
+      }
+    },
+    [lines, row, col, moveTo]
+  );
+
+  const doSearch = useCallback(
+    (term: string, fromRow: number, fromCol: number, backward = false) => {
+      if (!term) return false;
+      const total = lines.length;
+      for (let i = 0; i <= total; i++) {
+        const r = backward
+          ? (fromRow - i + total * 2) % total
+          : (fromRow + i) % total;
+        const line = lines[r] ?? "";
+        let idx: number;
+        if (i === 0) {
+          idx = backward
+            ? line.lastIndexOf(term, fromCol - 1)
+            : line.indexOf(term, fromCol + 1);
+        } else {
+          idx = backward ? line.lastIndexOf(term) : line.indexOf(term);
+        }
+        if (idx >= 0) {
+          moveTo(r, idx);
+          setMessage(`/${term}`);
+          return true;
+        }
+      }
+      setMessage(`E486: Pattern not found: ${term}`);
+      return false;
+    },
+    [lines, moveTo]
+  );
+
+  const runExCommand = useCallback(
+    (cmd: string) => {
+      const c = cmd.trim();
+      if (c === "q" || c === "q!" || c === "qa" || c === "qa!") {
+        if (c === "q" && modified) {
+          setMessage("E37: No write since last change (add ! to override)");
+          return;
+        }
+        onExit();
+      } else if (c === "w" || c === "wq" || c === "x" || c === "wq!") {
+        if (readOnly) {
+          setMessage(`E45: 'readonly' option is set for "${filename}"`);
+          return;
+        }
+        const err = onSave(lines.join("\n"));
+        if (err) {
+          setMessage(err);
+          return;
+        }
+        setModified(false);
+        setMessage(`"${filename}" ${lines.length}L written (in-memory — refresh resets it)`);
+        if (c !== "w") onExit();
+      } else if (c === "set nu" || c === "set number") {
+        setShowNumbers(true);
+      } else if (c === "set nonu" || c === "set nonumber") {
+        setShowNumbers(false);
+      } else if (/^\d+$/.test(c)) {
+        moveTo(parseInt(c, 10) - 1, 0);
+      } else if (c === "help" || c === "h") {
+        setMessage("movement: hjkl w b 0 $ gg G · edit: i a o x dd yy p u · :w :q :wq · /search n N");
+      } else if (c === "smile") {
+        setMessage("=^.^=  have a nice day!");
+      } else if (c === "") {
+        // no-op
+      } else {
+        setMessage(`E492: Not an editor command: ${c}`);
+      }
+    },
+    [modified, lines, filename, readOnly, onSave, onExit, moveTo]
+  );
+
+  const handleNormalKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      const k = e.key;
+
+      // pending two-key combos: dd, yy, gg
+      if (pending.current) {
+        const p = pending.current;
+        pending.current = "";
+        if (p === "d" && k === "d") {
+          snapshot();
+          yankBuf.current = [lines[row]];
+          const nl = lines.filter((_, i) => i !== row);
+          mutate(nl, Math.min(row, Math.max(0, nl.length - 1)), 0);
+          setMessage("1 line deleted");
+          return;
+        }
+        if (p === "y" && k === "y") {
+          yankBuf.current = [lines[row]];
+          setMessage("1 line yanked");
+          return;
+        }
+        if (p === "g" && k === "g") {
+          moveTo(0, 0);
+          return;
+        }
+        // fall through: treat current key normally
+      }
+
+      if (k === "d" || k === "y" || k === "g") {
+        pending.current = k;
+        return;
+      }
+
+      switch (k) {
+        case "h": case "ArrowLeft": moveTo(row, col - 1); break;
+        case "l": case "ArrowRight": moveTo(row, col + 1); break;
+        case "j": case "ArrowDown": moveTo(row + 1, col); break;
+        case "k": case "ArrowUp": moveTo(row - 1, col); break;
+        case "0": case "Home": moveTo(row, 0); break;
+        case "$": case "End": moveTo(row, Math.max(0, (lines[row] ?? "").length - 1)); break;
+        case "^": moveTo(row, Math.max(0, (lines[row] ?? "").search(/\S/))); break;
+        case "w": wordJump(true, false); break;
+        case "e": wordJump(true, true); break;
+        case "b": wordJump(false, false); break;
+        case "G": moveTo(lines.length - 1, 0); break;
+        case "i": snapshot(); setMode("insert"); setMessage("-- INSERT --"); break;
+        case "I": snapshot(); moveTo(row, Math.max(0, (lines[row] ?? "").search(/\S/)), true); setMode("insert"); setMessage("-- INSERT --"); break;
+        case "a": snapshot(); setCol(clampCol(row, col + 1, true)); setMode("insert"); setMessage("-- INSERT --"); break;
+        case "A": snapshot(); setCol((lines[row] ?? "").length); setMode("insert"); setMessage("-- INSERT --"); break;
+        case "o": {
+          snapshot();
+          const nl = [...lines];
+          nl.splice(row + 1, 0, "");
+          mutate(nl, row + 1, 0);
+          setMode("insert");
+          setMessage("-- INSERT --");
+          break;
+        }
+        case "O": {
+          snapshot();
+          const nl = [...lines];
+          nl.splice(row, 0, "");
+          mutate(nl, row, 0);
+          setMode("insert");
+          setMessage("-- INSERT --");
+          break;
+        }
+        case "x": {
+          const line = lines[row] ?? "";
+          if (!line) break;
+          snapshot();
+          const nl = [...lines];
+          nl[row] = line.slice(0, col) + line.slice(col + 1);
+          mutate(nl, row, clampCol(row, col, false));
+          break;
+        }
+        case "D": {
+          snapshot();
+          const nl = [...lines];
+          nl[row] = (lines[row] ?? "").slice(0, col);
+          mutate(nl, row, Math.max(0, col - 1));
+          break;
+        }
+        case "p": case "P": {
+          if (!yankBuf.current) break;
+          snapshot();
+          const nl = [...lines];
+          const at = k === "p" ? row + 1 : row;
+          nl.splice(at, 0, ...yankBuf.current);
+          mutate(nl, at, 0);
+          break;
+        }
+        case "u": {
+          const snap = undoStack.current.pop();
+          if (snap) {
+            setLines(snap.lines);
+            setRow(snap.row);
+            setCol(snap.col);
+            setMessage("undo");
+          } else {
+            setMessage("Already at oldest change");
+          }
+          break;
+        }
+        case "n": doSearch(searchTerm.current, row, col); break;
+        case "N": doSearch(searchTerm.current, row, col, true); break;
+        case ":": setMode("command"); setCmdline(":"); break;
+        case "/": setMode("command"); setCmdline("/"); break;
+        case "Escape": pending.current = ""; setMessage(""); break;
+        default:
+          if (k === "d" && e.ctrlKey) moveTo(row + 10, col);
+          break;
+      }
+      if (e.ctrlKey && k === "d") moveTo(row + 10, col);
+      if (e.ctrlKey && k === "u") moveTo(row - 10, col);
+    },
+    [lines, row, col, moveTo, clampCol, mutate, snapshot, wordJump, doSearch]
+  );
+
+  const handleInsertKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      const k = e.key;
+      if (k === "Escape") {
+        setMode("normal");
+        setCol((c) => clampCol(row, c - 1, false));
+        setMessage("");
+        return;
+      }
+      const line = lines[row] ?? "";
+      if (k === "Enter") {
+        const nl = [...lines];
+        nl.splice(row, 1, line.slice(0, col), line.slice(col));
+        mutate(nl, row + 1, 0);
+      } else if (k === "Backspace") {
+        if (col > 0) {
+          const nl = [...lines];
+          nl[row] = line.slice(0, col - 1) + line.slice(col);
+          mutate(nl, row, col - 1);
+        } else if (row > 0) {
+          const prev = lines[row - 1] ?? "";
+          const nl = [...lines];
+          nl.splice(row - 1, 2, prev + line);
+          mutate(nl, row - 1, prev.length);
+        }
+      } else if (k === "Tab") {
+        const nl = [...lines];
+        nl[row] = line.slice(0, col) + "  " + line.slice(col);
+        mutate(nl, row, col + 2);
+      } else if (k === "ArrowLeft") setCol((c) => Math.max(0, c - 1));
+      else if (k === "ArrowRight") setCol((c) => Math.min(line.length, c + 1));
+      else if (k === "ArrowUp") moveTo(row - 1, col, true);
+      else if (k === "ArrowDown") moveTo(row + 1, col, true);
+      else if (k.length === 1 && !e.ctrlKey && !e.metaKey) {
+        const nl = [...lines];
+        nl[row] = line.slice(0, col) + k + line.slice(col);
+        mutate(nl, row, col + 1);
+      }
+    },
+    [lines, row, col, clampCol, mutate, moveTo]
+  );
+
+  const handleCommandKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      const k = e.key;
+      if (k === "Escape") {
+        setMode("normal");
+        setCmdline("");
+      } else if (k === "Enter") {
+        const c = cmdline;
+        setMode("normal");
+        setCmdline("");
+        if (c.startsWith(":")) runExCommand(c.slice(1));
+        else if (c.startsWith("/")) {
+          searchTerm.current = c.slice(1);
+          doSearch(searchTerm.current, row, col);
+        }
+      } else if (k === "Backspace") {
+        setCmdline((c) => {
+          if (c.length <= 1) {
+            setMode("normal");
+            return "";
+          }
+          return c.slice(0, -1);
+        });
+      } else if (k.length === 1 && !e.ctrlKey && !e.metaKey) {
+        setCmdline((c) => c + k);
+      }
+    },
+    [cmdline, runExCommand, doSearch, row, col]
+  );
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (mode === "normal") handleNormalKey(e);
+    else if (mode === "insert") handleInsertKey(e);
+    else handleCommandKey(e);
+  };
+
+  const gutterWidth = String(lines.length).length;
+
+  return (
+    <div
+      ref={containerRef}
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      onBlur={() => containerRef.current?.focus()}
+      className="flex flex-col h-full outline-none text-sm"
+    >
+      <div className="flex-1 overflow-y-auto term-scrollbar leading-snug">
+        {lines.map((line, r) => (
+          <div key={r} className="whitespace-pre-wrap break-all flex">
+            {showNumbers && (
+              <span className="t-dim select-none shrink-0 pr-3 text-right" style={{ width: `${gutterWidth + 2}ch` }}>
+                {r + 1}
+              </span>
+            )}
+            <span className="whitespace-pre-wrap break-all">
+              {r === row ? renderCursorLine(line, col, mode, cursorRef) : line || " "}
+            </span>
+          </div>
+        ))}
+        {Array.from({ length: Math.max(0, 3) }).map((_, i) => (
+          <div key={`tilde-${i}`} className="t-dim select-none">~</div>
+        ))}
+      </div>
+      <div
+        className="shrink-0 flex justify-between px-2 py-0.5 text-xs"
+        style={{ background: "var(--t-selection)" }}
+      >
+        <span>
+          <span className={mode === "insert" ? "t-warn" : "t-acc"}>
+            {mode === "insert" ? "-- INSERT --" : mode === "command" ? "" : "NORMAL"}
+          </span>{" "}
+          <span className="t-dim">
+            {filename}
+            {modified ? " [+]" : ""}
+            {readOnly ? " [RO]" : ""}
+          </span>
+        </span>
+        <span className="t-dim">
+          {row + 1},{col + 1} · {Math.round(((row + 1) / lines.length) * 100)}%
+        </span>
+      </div>
+      <div className="shrink-0 px-2 h-5 text-xs">
+        {mode === "command" ? (
+          <span>
+            {cmdline}
+            <span className="term-block-cursor" />
+          </span>
+        ) : (
+          <span className="t-dim">{message}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function renderCursorLine(
+  line: string,
+  col: number,
+  mode: Mode,
+  cursorRef: React.RefObject<HTMLSpanElement>
+) {
+  const c = Math.min(col, Math.max(0, line.length));
+  const before = line.slice(0, c);
+  const at = line[c] ?? " ";
+  const after = line.slice(c + 1);
+  return (
+    <>
+      {before}
+      <span ref={cursorRef} className={mode === "insert" ? "vim-cursor-insert" : "vim-cursor"}>
+        {at}
+      </span>
+      {after}
+    </>
+  );
+}

--- a/lib/terminal/ascii.ts
+++ b/lib/terminal/ascii.ts
@@ -1,0 +1,147 @@
+export const BANNER = String.raw`             _              _            _
+  _ __ _   _(_) __   ____ _| | ___ _ __ | |_ ___
+ | '__| | | | | \ \ / / _` + "`" + String.raw` | |/ _ \ '_ \| __/ _ \
+ | |  | |_| | |  \ V / (_| | |  __/ | | | ||  __/
+ |_|   \__,_|_|   \_/ \__,_|_|\___|_| |_|\__\___|`;
+
+export const NEOFETCH_LOGO = [
+  "        ▄▄▄▄▄▄▄▄        ",
+  "     ▄█▀▀      ▀▀█▄     ",
+  "   ▄█▀   ▄████▄   ▀█▄   ",
+  "  ██    ██▀  ▀██    ██  ",
+  "  ██    ██▄  ▄██    ██  ",
+  "  ██     ▀████▀     ██  ",
+  "   ▀█▄    ▄██▄    ▄█▀   ",
+  "     ▀█▄ ██▀▀██ ▄█▀     ",
+  "        ▀▀▀  ▀▀▀        ",
+];
+
+export const VADER = String.raw`
+        .-.
+       |_:_|
+      /(_Y_)\
+     ( \/M\/ )
+      '. _.'-/'.
+        '-  \  \
+          \  \\
+          |\\/\\
+          | _ -\\
+          |     )
+          |    /
+   I find your lack of
+   light theme disturbing.`;
+
+export const TRAIN = String.raw`      ====        ________                ___________
+  _D _|  |_______/        \__I_I_____===__|_________|
+   |(_)---  |   H\________/ |   |        =|___ ___|
+   /     |  |   H  |  |     |   |         ||_| |_||
+  |      |  |   H  |__--------------------| [___] |
+  | ________|___H__/__|_____/[][]~\_______|       |
+  |/ |   |-----------I_____I [][] []  D   |=======|__
+__/ =| o |=-~~\  /~~\  /~~\  /~~\ ____Y___________|__
+ |/-=|___|=    ||    ||    ||    |_____/~\___/
+  \_/      \O=====O=====O=====O_/      \_/`;
+
+export const COFFEE = String.raw`      ( (
+       ) )
+    ........
+    |      |]
+    \      /
+     '----'
+  coffee.exe loaded`;
+
+export function cowsay(message: string): string {
+  const msg = message || "moo";
+  const lines: string[] = [];
+  const words = msg.split(/\s+/);
+  let cur = "";
+  for (const w of words) {
+    if ((cur + " " + w).trim().length > 38) {
+      lines.push(cur.trim());
+      cur = w;
+    } else cur = (cur + " " + w).trim();
+  }
+  if (cur) lines.push(cur);
+  const width = Math.max(...lines.map((l) => l.length));
+  const pad = (s: string) => s + " ".repeat(width - s.length);
+  const bubble =
+    lines.length === 1
+      ? [`< ${pad(lines[0])} >`]
+      : lines.map((l, i) => {
+          const [o, c] =
+            i === 0 ? ["/", "\\"] : i === lines.length - 1 ? ["\\", "/"] : ["|", "|"];
+          return `${o} ${pad(l)} ${c}`;
+        });
+  return [
+    " " + "_".repeat(width + 2),
+    ...bubble,
+    " " + "-".repeat(width + 2),
+    "        \\   ^__^",
+    "         \\  (oo)\\_______",
+    "            (__)\\       )\\/\\",
+    "                ||----w |",
+    "                ||     ||",
+  ].join("\n");
+}
+
+export const FORTUNES = [
+  "There are only two hard things in computer science: cache invalidation, naming things, and off-by-one errors.",
+  "It works on my machine. — every developer, moments before disaster",
+  "A SQL query walks into a bar, walks up to two tables and asks: 'Can I JOIN you?'",
+  "99 little bugs in the code, 99 little bugs. Take one down, patch it around... 127 little bugs in the code.",
+  "Weeks of coding can save you hours of planning.",
+  "The best error message is the one that never shows up. The worst is 'undefined is not a function'.",
+  "Documentation is a love letter you write to your future self.",
+  "Programmer (n.): a machine that turns coffee into code.",
+  "Real programmers count from 0.",
+  "If debugging is the process of removing bugs, then programming must be the process of putting them in. — Dijkstra",
+  "git commit -m 'fix' && git commit -m 'actually fix' && git commit -m 'please work'",
+  "There is no place like 127.0.0.1",
+  "Software and cathedrals are much the same — first we build them, then we pray.",
+  "A user interface is like a joke: if you have to explain it, it's not that good.",
+  "Why do Java developers wear glasses? Because they don't C#.",
+];
+
+export const TYPING_QUOTES = [
+  "talk is cheap show me the code",
+  "premature optimization is the root of all evil",
+  "simplicity is the ultimate sophistication",
+  "first solve the problem then write the code",
+  "programs must be written for people to read",
+  "any sufficiently advanced bug is indistinguishable from a feature",
+  "the most disastrous thing you can learn is your first programming language",
+  "code never lies comments sometimes do",
+];
+
+export const HACK_LINES = [
+  "initializing exploit framework v4.2.0...",
+  "scanning ports... 22 80 443 1337 open",
+  "bypassing firewall............ OK",
+  "spoofing MAC address.......... OK",
+  "injecting payload [██████████░░░░░] 67%",
+  "injecting payload [████████████████] 100%",
+  "cracking RSA-4096 with a for-loop... OK (?)",
+  "downloading mainframe......... OK",
+  "enhancing... enhancing... ENHANCED",
+  "access granted. welcome, agent.",
+  "",
+  "(disclaimer: absolutely nothing happened)",
+];
+
+export const RM_RF_LINES = [
+  "rm: descending into '/usr'...",
+  "removed '/usr/bin/node'",
+  "removed '/usr/bin/vim'  (no!)",
+  "removed '/usr/lib/libc.so.6'  (uh oh)",
+  "rm: descending into '/home'...",
+  "removed '/home/guest/projects'",
+  "removed '/home/guest/resume.pdf'",
+  "rm: descending into '/boot'...",
+  "removed '/boot/vmlinuz'",
+  "kernel panic - not syncing: attempted to kill init!",
+  "",
+  "...",
+  "",
+  "just kidding 😄 this filesystem is read-only and made of JSON.",
+  "but maybe don't run that on your real machine.",
+];

--- a/lib/terminal/build-fs.ts
+++ b/lib/terminal/build-fs.ts
@@ -1,0 +1,329 @@
+import {
+  projects,
+  experiences,
+  education,
+  certificates,
+  profile,
+  social,
+  hobbies,
+  stack,
+} from "@/lib/data";
+import { VDir, VFile, dir, file, slugify } from "./filesystem";
+
+/**
+ * Build the virtual filesystem for the terminal from the same data that
+ * powers the rest of the website. `contentMap` maps a contentPath
+ * (e.g. "/content/projects/lazylife.md") to its raw markdown, read
+ * server-side.
+ */
+export function buildFileSystem(contentMap: Record<string, string>): VDir {
+  const md = (path?: string) => (path && contentMap[path]) || "";
+
+  const projectFiles: VFile[] = projects.map((p: any) =>
+    file(
+      `${p.id}.md`,
+      [
+        `# ${p.title}`,
+        "",
+        p.description,
+        "",
+        `demo:    ${p.demo}`,
+        `github:  ${p.github}`,
+        "",
+        `skills:  ${p.skills.join(", ")}`,
+        "",
+        "---",
+        "",
+        md(p.contentPath).trim(),
+      ].join("\n"),
+      { url: p.demo }
+    )
+  );
+
+  const experienceFiles: VFile[] = experiences.map((e: any) =>
+    file(
+      `${e.id}.md`,
+      [
+        `# ${e.role} @ ${e.company}`,
+        "",
+        `period:  ${e.year}`,
+        `company: ${e.companyUrl}`,
+        "",
+        `skills:  ${e.skills.join(", ")}`,
+        "",
+        "---",
+        "",
+        md(e.contentPath).trim(),
+      ].join("\n"),
+      { url: e.companyUrl }
+    )
+  );
+
+  const educationFiles: VFile[] = education.map((e: any) =>
+    file(
+      `${e.id}.md`,
+      [
+        `# ${e.degree}`,
+        "",
+        `school:  ${e.school}`,
+        `period:  ${e.year}`,
+        `url:     ${e.url}`,
+        "",
+        `skills:  ${e.skills.join(", ")}`,
+        "",
+        "---",
+        "",
+        md(e.contentPath).trim(),
+      ].join("\n"),
+      { url: e.url }
+    )
+  );
+
+  const certificateFiles: VFile[] = certificates.map((c: any) =>
+    file(
+      `${slugify(c.name)}.md`,
+      [
+        `# ${c.name}`,
+        "",
+        `issuer:  ${c.issuer}`,
+        `year:    ${c.year}`,
+        `url:     ${c.url}`,
+        "",
+        "tip: `open` this file to view the certificate",
+      ].join("\n"),
+      { url: c.url }
+    )
+  );
+
+  const stackFiles: VFile[] = stack.map((cat: any) =>
+    file(
+      `${slugify(cat.category)}.txt`,
+      [
+        `# ${cat.category}`,
+        "",
+        ...cat.items.flatMap((i: any) => [
+          `* ${i.name}`,
+          `  ${i.description}`,
+          `  why: ${i.reason}`,
+          "",
+        ]),
+      ].join("\n")
+    )
+  );
+
+  const aboutTxt = file(
+    "about.txt",
+    [
+      `name:  ${profile.name}`,
+      `role:  ${profile.role}`,
+      `bio:   ${profile.bio}`,
+      `email: ${profile.email}`,
+      "",
+      "Software engineer from Portugal 🇵🇹 building things for the web.",
+      "Check ./projects, ./experience and ./education for the full story,",
+      "or run `neofetch` for the fancy version.",
+    ].join("\n")
+  );
+
+  const contactTxt = file(
+    "contact.txt",
+    [
+      `email:    ${profile.email}`,
+      ...social.map((s: any) => `${s.icon.toLowerCase().padEnd(9)} ${s.url}`),
+      "",
+      "tip: run `email` to open your mail client, `social` for clickable links.",
+    ].join("\n")
+  );
+
+  const hobbiesDir = dir("hobbies", [
+    file(
+      "playlist.txt",
+      [
+        `# ${hobbies.playlist.title}`,
+        "",
+        hobbies.playlist.description,
+        hobbies.playlist.url,
+        "",
+        "tip: `open hobbies/playlist.txt` to start the music 🎵",
+      ].join("\n"),
+      { url: hobbies.playlist.url }
+    ),
+    file(
+      "watching.txt",
+      [
+        `# ${hobbies.watching.title}`,
+        "",
+        hobbies.watching.description,
+        hobbies.watching.url,
+      ].join("\n"),
+      { url: hobbies.watching.url }
+    ),
+  ]);
+
+  const readme = file("README.md", README);
+
+  const resume = file(
+    "resume.pdf",
+    "%PDF-1.7 — binary file.\nThis is a PDF, you nerd. Run `open resume.pdf` to view it.",
+    { url: "/resume.pdf", readOnly: true }
+  );
+
+  const secrets = dir(
+    ".secrets",
+    [
+      file(
+        "easter-eggs.txt",
+        [
+          "well well well... someone knows about `ls -a` 👀",
+          "",
+          "things you may want to try:",
+          "  sl                    you WILL typo `ls` eventually",
+          "  cowsay moo            a classic",
+          "  fortune               wisdom of the ancients",
+          "  cmatrix               follow the white rabbit",
+          "  crt / flip / glitch   mess with the display",
+          "  rm -rf /              what could possibly go wrong",
+          "  sudo su               become root",
+          "  darkside              join us. we have cookies.",
+          "  uuddlrlrba            ↑↑↓↓←→←→BA",
+          "  vim secret.txt        wait, that file doesn't exi— oh.",
+          "  coffee                mandatory developer fuel",
+          "  hack ruivalente.com   hollywood mode",
+          "",
+          "and yes, there are more. keep digging.",
+        ].join("\n"),
+        { hidden: false }
+      ),
+      file("do-not-open.txt", "you opened it.\n\n🐛\n\nnow you have a bug. it's yours. take care of it.", {}),
+    ],
+    true
+  );
+
+  const bashrc = file(
+    ".bashrc",
+    [
+      "# guest shell config",
+      'alias work="cd ~/experience && ls"',
+      'alias coffee="echo ☕ && echo back to work"',
+      'alias up="echo no. use cd .."',
+      "export PS1='guest@ruivalente:\\w$ '",
+      "export EDITOR=vim  # obviously",
+    ].join("\n"),
+    { hidden: true }
+  );
+
+  const vimtutor = file(
+    ".vimtutor",
+    [
+      "===  v i m t u t o r  (pocket edition)  ===",
+      "",
+      "Lesson 1: you are in NORMAL mode. keys are commands, not text.",
+      "  h j k l   move left / down / up / right (arrows work too)",
+      "  w / b     jump forward / back a word",
+      "  gg / G    top / bottom of file",
+      "  0 / $     start / end of line",
+      "",
+      "Lesson 2: editing",
+      "  i         insert before cursor      a   insert after",
+      "  o         open a new line below     O   above",
+      "  x         delete a character        dd  delete a line",
+      "  yy        yank (copy) a line        p   paste",
+      "  u         undo",
+      "  Esc       back to NORMAL mode",
+      "",
+      "Lesson 3: the part everyone googles",
+      "  :w        save        :q   quit",
+      "  :wq       save+quit   :q!  quit without saving",
+      "",
+      "Lesson 4: searching",
+      "  /word     search      n / N   next / previous match",
+      "",
+      "Now try it: delete this line with dd. Saved edits last until refresh.",
+      "When you're done, :q and go check out the games. You earned snake.",
+    ].join("\n"),
+    { hidden: true }
+  );
+
+  const home = dir("guest", [
+    readme,
+    vimtutor,
+    aboutTxt,
+    contactTxt,
+    resume,
+    dir("projects", projectFiles),
+    dir("experience", experienceFiles),
+    dir("education", educationFiles),
+    dir("certificates", certificateFiles),
+    dir("stack", stackFiles),
+    hobbiesDir,
+    secrets,
+    bashrc,
+  ]);
+
+  const etc = dir("etc", [
+    file(
+      "motd",
+      "Welcome to ruiOS. Unauthorized access is mandatory.\nReport bugs to /dev/null.",
+      {}
+    ),
+    file("hostname", "ruivalente.com"),
+  ]);
+
+  const varDir = dir("var", [
+    dir("log", [
+      file(
+        "coffee.log",
+        Array.from({ length: 8 }, (_, i) => {
+          const d = new Date();
+          d.setDate(d.getDate() - (7 - i));
+          return `${d.toISOString().slice(0, 10)} 0${(i % 3) + 7}:1${i}:00 [OK] coffee consumed (cup ${i + 1}/∞)`;
+        }).join("\n")
+      ),
+    ]),
+  ]);
+
+  const root = dir("/", []);
+  root.children["home"] = dir("home", [home]);
+  root.children["etc"] = etc;
+  root.children["var"] = varDir;
+  root.children["dev"] = dir("dev", [file("null", "", { readOnly: true })]);
+  return root;
+}
+
+const README = `# ruivalente.com — terminal edition
+
+Hi, fellow developer 👋  You found the terminal view of my portfolio.
+Everything on the regular website lives here too, as a tiny fake unix.
+
+## quick start
+
+  ls                  look around
+  cd projects         hop into a directory (tab-completion works!)
+  cat lazy-life.md    read a file
+  vim about.txt       or read it the hard way (:q to leave, you know the drill)
+  open resume.pdf     files with links open in a new tab
+  neofetch            mandatory system flex
+  theme               list color schemes, e.g. \`theme dracula\`
+  help                full command list
+
+## keyboard
+
+  Tab        autocomplete commands, paths, themes
+  ↑ / ↓      command history
+  Ctrl+L     clear screen
+  Ctrl+C     cancel current line / game
+  Ctrl+U     erase line
+
+## games
+
+  snake       the classic, arrow keys / wasd
+  tictactoe   you vs. a very smug AI
+  guess       number guessing, 1-100
+  typing      wpm test for keyboard warriors
+
+## boring version
+
+If you'd rather click things: type \`gui\` to go back to ruivalente.com.
+
+There are easter eggs. \`ls -a\` is your friend.
+`;

--- a/lib/terminal/filesystem.ts
+++ b/lib/terminal/filesystem.ts
@@ -1,0 +1,123 @@
+export interface VFile {
+  type: "file";
+  name: string;
+  content: string;
+  /** primary link opened by `open <file>` */
+  url?: string;
+  hidden?: boolean;
+  readOnly?: boolean;
+}
+
+export interface VDir {
+  type: "dir";
+  name: string;
+  children: Record<string, VNode>;
+  hidden?: boolean;
+}
+
+export type VNode = VFile | VDir;
+
+export const HOME = "/home/guest";
+
+export function dir(name: string, children: VNode[] = [], hidden = false): VDir {
+  const map: Record<string, VNode> = {};
+  children.forEach((c) => (map[c.name] = c));
+  return { type: "dir", name, children: map, hidden };
+}
+
+export function file(
+  name: string,
+  content: string,
+  opts: { url?: string; hidden?: boolean; readOnly?: boolean } = {}
+): VFile {
+  return { type: "file", name, content, ...opts };
+}
+
+/** Resolve a path (absolute, relative, ~ aware) into normalized absolute segments. */
+export function resolvePath(cwd: string, input: string): string {
+  let raw = input.trim();
+  if (raw === "" || raw === "~") raw = HOME;
+  else if (raw.startsWith("~/")) raw = HOME + raw.slice(1);
+  const base = raw.startsWith("/") ? [] : cwd.split("/").filter(Boolean);
+  const out = [...base];
+  for (const seg of raw.split("/")) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") out.pop();
+    else out.push(seg);
+  }
+  return "/" + out.join("/");
+}
+
+export function getNode(root: VDir, absPath: string): VNode | null {
+  const segs = absPath.split("/").filter(Boolean);
+  let node: VNode = root;
+  for (const seg of segs) {
+    if (node.type !== "dir") return null;
+    const next: VNode | undefined = node.children[seg];
+    if (!next) return null;
+    node = next;
+  }
+  return node;
+}
+
+export function displayPath(absPath: string): string {
+  if (absPath === HOME) return "~";
+  if (absPath.startsWith(HOME + "/")) return "~" + absPath.slice(HOME.length);
+  return absPath || "/";
+}
+
+export function listDir(node: VDir, showHidden: boolean): VNode[] {
+  return Object.values(node.children)
+    .filter((c) => showHidden || !c.hidden)
+    .sort((a, b) => {
+      if (a.type !== b.type) return a.type === "dir" ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+}
+
+/**
+ * Complete the last path segment of `partial` against the filesystem.
+ * Returns full replacement candidates for the partial (dirs get a trailing "/").
+ */
+export function completePath(
+  root: VDir,
+  cwd: string,
+  partial: string,
+  onlyDirs: boolean
+): string[] {
+  const slash = partial.lastIndexOf("/");
+  const basePart = slash >= 0 ? partial.slice(0, slash + 1) : "";
+  const prefix = slash >= 0 ? partial.slice(slash + 1) : partial;
+  const baseAbs = resolvePath(cwd, basePart === "" ? "." : basePart);
+  const baseNode = getNode(root, baseAbs);
+  if (!baseNode || baseNode.type !== "dir") return [];
+  return Object.values(baseNode.children)
+    .filter((c) => (!onlyDirs || c.type === "dir"))
+    .filter((c) => (c.hidden ? prefix.startsWith(".") : true))
+    .filter((c) => c.name.startsWith(prefix))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((c) => basePart + c.name + (c.type === "dir" ? "/" : ""));
+}
+
+/** Render an ASCII tree of a directory. */
+export function renderTree(node: VDir, showHidden = false, prefix = ""): string[] {
+  const entries = listDir(node, showHidden);
+  const out: string[] = [];
+  entries.forEach((child, i) => {
+    const last = i === entries.length - 1;
+    const branch = last ? "└── " : "├── ";
+    out.push(prefix + branch + child.name + (child.type === "dir" ? "/" : ""));
+    if (child.type === "dir") {
+      out.push(...renderTree(child, showHidden, prefix + (last ? "    " : "│   ")));
+    }
+  });
+  return out;
+}
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+}

--- a/lib/terminal/themes.ts
+++ b/lib/terminal/themes.ts
@@ -1,0 +1,205 @@
+export interface TermTheme {
+  name: string;
+  desc: string;
+  /** themes that need to be unlocked via easter eggs */
+  hidden?: boolean;
+  colors: {
+    bg: string;
+    fg: string;
+    dim: string;
+    accent: string;
+    green: string;
+    red: string;
+    yellow: string;
+    cyan: string;
+    magenta: string;
+    selection: string;
+  };
+}
+
+export const TERM_THEMES: TermTheme[] = [
+  {
+    name: "matrix",
+    desc: "green phosphor, the only true terminal",
+    colors: {
+      bg: "#050905",
+      fg: "#33ff66",
+      dim: "#1d8c44",
+      accent: "#aaffcc",
+      green: "#33ff66",
+      red: "#ff5555",
+      yellow: "#f1fa8c",
+      cyan: "#66ffe3",
+      magenta: "#ff79c6",
+      selection: "#0f3d22",
+    },
+  },
+  {
+    name: "dracula",
+    desc: "classic dark, bela lugosi approved",
+    colors: {
+      bg: "#282a36",
+      fg: "#f8f8f2",
+      dim: "#6272a4",
+      accent: "#bd93f9",
+      green: "#50fa7b",
+      red: "#ff5555",
+      yellow: "#f1fa8c",
+      cyan: "#8be9fd",
+      magenta: "#ff79c6",
+      selection: "#44475a",
+    },
+  },
+  {
+    name: "cyberpunk",
+    desc: "high tech, low life",
+    colors: {
+      bg: "#0a0b1b",
+      fg: "#00ffff",
+      dim: "#3d6e8c",
+      accent: "#ff00ff",
+      green: "#00ff9f",
+      red: "#ff2a6d",
+      yellow: "#f9f871",
+      cyan: "#00ffff",
+      magenta: "#ff00ff",
+      selection: "#1c2541",
+    },
+  },
+  {
+    name: "nord",
+    desc: "cold. very cold.",
+    colors: {
+      bg: "#2e3440",
+      fg: "#d8dee9",
+      dim: "#616e88",
+      accent: "#88c0d0",
+      green: "#a3be8c",
+      red: "#bf616a",
+      yellow: "#ebcb8b",
+      cyan: "#8fbcbb",
+      magenta: "#b48ead",
+      selection: "#434c5e",
+    },
+  },
+  {
+    name: "gruvbox",
+    desc: "warm and retro",
+    colors: {
+      bg: "#282828",
+      fg: "#ebdbb2",
+      dim: "#928374",
+      accent: "#fe8019",
+      green: "#b8bb26",
+      red: "#fb4934",
+      yellow: "#fabd2f",
+      cyan: "#8ec07c",
+      magenta: "#d3869b",
+      selection: "#3c3836",
+    },
+  },
+  {
+    name: "monokai",
+    desc: "the sublime classic",
+    colors: {
+      bg: "#272822",
+      fg: "#f8f8f2",
+      dim: "#75715e",
+      accent: "#66d9ef",
+      green: "#a6e22e",
+      red: "#f92672",
+      yellow: "#e6db74",
+      cyan: "#66d9ef",
+      magenta: "#ae81ff",
+      selection: "#49483e",
+    },
+  },
+  {
+    name: "solarized",
+    desc: "for people with opinions about contrast",
+    colors: {
+      bg: "#002b36",
+      fg: "#839496",
+      dim: "#586e75",
+      accent: "#268bd2",
+      green: "#859900",
+      red: "#dc322f",
+      yellow: "#b58900",
+      cyan: "#2aa198",
+      magenta: "#d33682",
+      selection: "#073642",
+    },
+  },
+  {
+    name: "ubuntu",
+    desc: "aubergine nostalgia",
+    colors: {
+      bg: "#300a24",
+      fg: "#eeeeec",
+      dim: "#a08599",
+      accent: "#e95420",
+      green: "#8ae234",
+      red: "#ef2929",
+      yellow: "#fce94f",
+      cyan: "#34e2e2",
+      magenta: "#ad7fa8",
+      selection: "#4e1f41",
+    },
+  },
+  {
+    name: "paper",
+    desc: "light mode. brave choice.",
+    colors: {
+      bg: "#f5f1e8",
+      fg: "#3a3530",
+      dim: "#8c8378",
+      accent: "#c05b2c",
+      green: "#3f7d3f",
+      red: "#c0392b",
+      yellow: "#9a7d0a",
+      cyan: "#16777e",
+      magenta: "#8e44ad",
+      selection: "#e0d8c8",
+    },
+  },
+  {
+    name: "sith",
+    desc: "the dark side of the force",
+    hidden: true,
+    colors: {
+      bg: "#0a0000",
+      fg: "#ff3b30",
+      dim: "#7a1f1a",
+      accent: "#ffffff",
+      green: "#ff6b5e",
+      red: "#ff0000",
+      yellow: "#ffb000",
+      cyan: "#ff8a80",
+      magenta: "#ff4569",
+      selection: "#3d0a05",
+    },
+  },
+  {
+    name: "synthwave",
+    desc: "konami-grade neon. you earned this.",
+    hidden: true,
+    colors: {
+      bg: "#241b2f",
+      fg: "#f8f8f2",
+      dim: "#8a7aa0",
+      accent: "#ff7edb",
+      green: "#72f1b8",
+      red: "#fe4450",
+      yellow: "#fede5d",
+      cyan: "#36f9f6",
+      magenta: "#ff7edb",
+      selection: "#463465",
+    },
+  },
+];
+
+export const DEFAULT_THEME = "matrix";
+
+export function getTheme(name: string): TermTheme {
+  return TERM_THEMES.find((t) => t.name === name) || TERM_THEMES[0];
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Serve the terminal view at terminal.ruivalente.com.
+ * (Requires the subdomain to be added to the deployment — see DOMAIN_SETUP.md.)
+ */
+export function middleware(req: NextRequest) {
+  const host = req.headers.get("host") ?? "";
+  if (host.startsWith("terminal.")) {
+    const url = req.nextUrl.clone();
+    if (!url.pathname.startsWith("/terminal")) {
+      url.pathname = "/terminal";
+      return NextResponse.rewrite(url);
+    }
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  // skip static assets and api routes
+  matcher: ["/((?!api|_next|.*\\..*).*)"],
+};

--- a/styles/terminal.css
+++ b/styles/terminal.css
@@ -1,0 +1,126 @@
+/* Terminal view — themed via CSS variables set inline by the Terminal component */
+
+.term-root {
+  background: var(--t-bg);
+  color: var(--t-fg);
+  font-family: var(--font-space-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.term-root ::selection {
+  background: var(--t-selection);
+  color: var(--t-fg);
+}
+
+.t-dim { color: var(--t-dim); }
+.t-acc { color: var(--t-accent); }
+.t-ok { color: var(--t-green); }
+.t-err { color: var(--t-red); }
+.t-warn { color: var(--t-yellow); }
+.t-cyan { color: var(--t-cyan); }
+.t-mag { color: var(--t-magenta); }
+
+.t-link {
+  color: var(--t-cyan);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.t-link:hover { color: var(--t-accent); }
+
+.term-input {
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--t-fg);
+  caret-color: var(--t-accent);
+  font: inherit;
+  width: 100%;
+}
+
+.term-block-cursor {
+  display: inline-block;
+  width: 0.6em;
+  height: 1.15em;
+  vertical-align: text-bottom;
+  background: var(--t-accent);
+  animation: term-blink 1.1s steps(1) infinite;
+}
+
+@keyframes term-blink {
+  50% { opacity: 0; }
+}
+
+/* ---- effects ---- */
+
+.term-crt::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 40;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.18) 0px,
+    rgba(0, 0, 0, 0.18) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+}
+.term-crt::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 41;
+  background: radial-gradient(ellipse at center, transparent 60%, rgba(0, 0, 0, 0.35) 100%);
+}
+
+.term-flip {
+  transform: rotate(180deg);
+}
+
+.term-glitch {
+  animation: term-glitch-anim 0.25s steps(2) infinite;
+}
+@keyframes term-glitch-anim {
+  0% { transform: translate(0, 0) skewX(0deg); filter: none; }
+  25% { transform: translate(-3px, 1px) skewX(-1deg); filter: hue-rotate(90deg); }
+  50% { transform: translate(3px, -1px) skewX(1deg); filter: invert(0.1); }
+  75% { transform: translate(-1px, 2px); filter: hue-rotate(-60deg); }
+  100% { transform: translate(0, 0); filter: none; }
+}
+
+/* steam locomotive (sl) */
+.term-sl-track {
+  position: relative;
+  overflow: hidden;
+  height: 11rem;
+}
+.term-sl-train {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  animation: term-sl-ride 6s linear forwards;
+  white-space: pre;
+}
+@keyframes term-sl-ride {
+  from { transform: translateX(0); }
+  to { transform: translateX(calc(-100vw - 60ch)); }
+}
+
+/* vim cursor */
+.vim-cursor {
+  background: var(--t-accent);
+  color: var(--t-bg);
+}
+.vim-cursor-insert {
+  box-shadow: inset 2px 0 0 var(--t-accent);
+}
+
+.term-scrollbar::-webkit-scrollbar { width: 8px; }
+.term-scrollbar::-webkit-scrollbar-track { background: transparent; }
+.term-scrollbar::-webkit-scrollbar-thumb {
+  background: var(--t-selection);
+  border-radius: 4px;
+}
+.term-scrollbar { scrollbar-width: thin; scrollbar-color: var(--t-selection) transparent; }


### PR DESCRIPTION
# Terminal portfolio view 🖥️

A complete interactive unix-style terminal at **`/terminal`** (and `terminal.ruivalente.com` via middleware rewrite) that mirrors **every section of the website** as a virtual filesystem built from the exact same data (`lib/data/*.json` + `content/*.md`). The regular website is untouched.

## What's inside

### Virtual filesystem (all current site data)
```
~/
├── README.md            full instructions for visiting developers
├── about.txt            profile/bio        ├── projects/      both projects + markdown content
├── contact.txt          email + socials    ├── experience/    all 3 positions
├── resume.pdf           `open` launches it ├── education/     both degrees
├── hobbies/             playlist+watching  ├── certificates/  all 5 certs (openable)
└── .secrets/            👀                 └── stack/         every stack category
```

### Shell
- `ls` (`-a`/`-l`), `cd`, `pwd`, `cat`, `tree`, `grep`, `open`, `echo`, `history`, `man`, `neofetch`, `contact`, `social`, `email`, `resume`, `gui`/`exit` back to the classic site
- **Tab autocomplete** for commands, file paths, theme names and games (bash-style: fills common prefix, lists candidates)
- ↑/↓ history (persisted), `Ctrl+L` clear, `Ctrl+C` cancel, `Ctrl+U` erase line

### Vim
Real modal editor: normal/insert/command modes, `hjkl`, `w`/`b`/`e`, `gg`/`G`, `0`/`$`, `i a o O A I`, `x dd yy p u`, `/search` + `n`/`N`, `:w :q :wq :q!`, line numbers, status bar — plus `vimtutor`. `:w` persists to the in-memory fs for the session (you can even `vim newfile.txt`).

### Themes
`theme` lists 11 schemes (matrix, dracula, cyberpunk, nord, gruvbox, monokai, solarized, ubuntu, paper + 2 **unlockable**: sith, synthwave). Persisted in localStorage.

### Mini games
- 🐍 `snake` — arrows/wasd, pause, high score in localStorage
- ⭕ `tictactoe` — vs a win/block/center/corner AI
- 🔢 `guess` — judges your search algorithm
- ⌨️ `typing` — WPM + accuracy test

### Easter eggs
`sl`, `cowsay`, `fortune`, `cmatrix` rain, `crt`/`flip`/`glitch`/`reset` effects, `sudo su`, `rm -rf /` (fake meltdown), `hack`, `coffee`, `darkside`/`jedi` (Vader + sith theme), konami code (`uuddlrlrba` → synthwave theme), `ping`, `top`, `:q` in the shell, hidden `~/.secrets/easter-eggs.txt` and more.

## Site integration
- Footer nav, sitemap and `/easter-eggs` page now mention the terminal
- `middleware.ts` rewrites `terminal.<domain>` → `/terminal` (subdomain just needs to be added on Vercel, see DOMAIN_SETUP.md)

## Verification
- `tsc --noEmit` and `next build` pass; `/terminal` builds as a static 23 kB page
- Playwright e2e against the production build: tab completion (`cat la⇥` → `cat lazy-life.md`), vim insert+`:wq`+`grep` roundtrip, all 4 games, sudo/darkside/matrix/theme switching — all green, zero console/page errors
- Smoke-tested `/`, `/projects`, `/easter-eggs` — unchanged and error-free

https://claude.ai/code/session_01Xirjq9fiQfKT3mvjZFWdXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xirjq9fiQfKT3mvjZFWdXF)_